### PR TITLE
use g++ instead of gcc for libcddgmp check

### DIFF
--- a/m4/gfanlib-check.m4
+++ b/m4/gfanlib-check.m4
@@ -25,7 +25,7 @@ if test "x$ENABLE_GFANLIB" != "xno"; then
 
  LIBS="$LIBS -lcddgmp $GMP_LIBS "
 
- AC_LANG_PUSH(C)
+ AC_LANG_PUSH(C++)
  AC_LINK_IFELSE(
   [
    AC_LANG_PROGRAM(


### PR DESCRIPTION
is it safe to use g++ instead of gcc for libcddgmp check ?
- otherwise the check fails on ubuntu 12.04 with 
```undefined reference to `dd_set_global_constants' ' ```

in the web this issue is explained by namespace issues 
