### PR TITLE
autotools chain: CPPFLAGS overwrite

### DIFF
--- a/omalloc/configure.ac
+++ b/omalloc/configure.ac
@@ -98,7 +98,7 @@ dnl  CFLAGS="-O"
 dnl  ac_cflags_set=no
 dnl fi
 
-CPPFLAGS="-I.. -I."
+CPPFLAGS="-I.. -I. $CPPFLAGS"
 AC_PROG_MAKE_SET
 AC_PROG_CC
 AC_PROG_CPP


### PR DESCRIPTION
 Fix CPPFLAGS overwrite issue observed in the omalloc package.