### PR TITLE
chg: allow users to pass dp and ds as orderings + code cleanup suggested by Hans and Oleksandr

### DIFF
--- a/Singular/dyn_modules/gfanlib/bbfan.cc
+++ b/Singular/dyn_modules/gfanlib/bbfan.cc
@@ -126,15 +126,15 @@ static gfan::IntMatrix permutationIntMatrix(const bigintmat* iv)
   int cc = iv->cols();
   int rr = iv->rows();
   bigintmat* ivCopy = new bigintmat(rr, cc, coeffs_BIGINT);
+  number temp1 = n_Init(1,coeffs_BIGINT);
   for (int r = 1; r <= rr; r++)
     for (int c = 1; c <= cc; c++)
     {
-      number temp1 = n_Init(1,coeffs_BIGINT);
       number temp2 = n_Sub(IMATELEM(*iv, r, c),temp1,coeffs_BIGINT);
       ivCopy->set(r,c,temp2);
-      n_Delete(&temp1,coeffs_BIGINT);
       n_Delete(&temp2,coeffs_BIGINT);
     }
+  n_Delete(&temp1,coeffs_BIGINT);
   gfan::ZMatrix* zm = bigintmatToZMatrix(ivCopy);
   gfan::IntMatrix im = gfan::IntMatrix(gfan::ZToIntMatrix(*zm));
   delete zm;
@@ -462,39 +462,39 @@ BOOLEAN containsInCollection(leftv res, leftv args)
   return TRUE;
 }
 
-BOOLEAN coneContaining(leftv res, leftv args)
-{
-  leftv u=args;
-  if ((u != NULL) && (u->Typ() == fanID))
-  {
-    leftv v=u->next;
-    if ((v != NULL) && ((v->Typ() == BIGINTMAT_CMD) || (v->Typ() == INTVEC_CMD)))
-    {
-      gfan::ZFan* zf = (gfan::ZFan*)u->Data();
-      gfan::ZVector* point;
-      if (v->Typ() == INTVEC_CMD)
-      {
-        intvec* w0 = (intvec*) v->Data();
-        bigintmat* w1 = iv2bim(w0,coeffs_BIGINT);
-        w1->inpTranspose();
-        point = bigintmatToZVector(*w1);
-        delete w1;
-      }
-      else
-      {
-        bigintmat* w1 = (bigintmat*) v->Data();
-        point = bigintmatToZVector(*w1);
-      }
-      lists L = (lists)omAllocBin(slists_bin);
-      res->rtyp = LIST_CMD;
-      res->data = (void*) L;
-      delete point;
-      return FALSE;
-    }
-  }
-  WerrorS("coneContaining: unexpected parameters");
-  return TRUE;
-}
+// BOOLEAN coneContaining(leftv res, leftv args)
+// {
+//   leftv u=args;
+//   if ((u != NULL) && (u->Typ() == fanID))
+//   {
+//     leftv v=u->next;
+//     if ((v != NULL) && ((v->Typ() == BIGINTMAT_CMD) || (v->Typ() == INTVEC_CMD)))
+//     {
+//       gfan::ZFan* zf = (gfan::ZFan*)u->Data();
+//       gfan::ZVector* point;
+//       if (v->Typ() == INTVEC_CMD)
+//       {
+//         intvec* w0 = (intvec*) v->Data();
+//         bigintmat* w1 = iv2bim(w0,coeffs_BIGINT);
+//         w1->inpTranspose();
+//         point = bigintmatToZVector(*w1);
+//         delete w1;
+//       }
+//       else
+//       {
+//         bigintmat* w1 = (bigintmat*) v->Data();
+//         point = bigintmatToZVector(*w1);
+//       }
+//       lists L = (lists)omAllocBin(slists_bin);
+//       res->rtyp = LIST_CMD;
+//       res->data = (void*) L;
+//       delete point;
+//       return FALSE;
+//     }
+//   }
+//   WerrorS("coneContaining: unexpected parameters");
+//   return TRUE;
+// }
 
 BOOLEAN removeCone(leftv res, leftv args)
 {

--- a/Singular/dyn_modules/gfanlib/tropicalStrategy.cc
+++ b/Singular/dyn_modules/gfanlib/tropicalStrategy.cc
@@ -173,29 +173,32 @@ static ring constructStartingRing(ring r)
   s->block1[0] = n;
   s->wvhdl[0] = (int*) omAlloc(n*sizeof(int));
   s->wvhdl[0][0] = 1;
-  for (int i=1; i<n; i++)
-    s->wvhdl[0][i] = -(r->wvhdl[0][i-1]);
+  if (r->order[0] == ringorder_dp)
+  {
+    for (int i=1; i<n; i++)
+      s->wvhdl[0][i] = -1;
+  }
+  else if (r->order[0] == ringorder_ds)
+  {
+    for (int i=1; i<n; i++)
+      s->wvhdl[0][i] = 1;
+  }
+  else if (r->order[0] == ringorder_ws)
+  {
+    for (int i=1; i<n; i++)
+      s->wvhdl[0][i] = r->wvhdl[0][i-1];
+  }
+  else
+  {
+    for (int i=1; i<n; i++)
+      s->wvhdl[0][i] = -r->wvhdl[0][i-1];
+  }
   s->order[1] = ringorder_C;
 
   rComplete(s);
   rTest(s);
   return s;
 }
-
-#if 0 /*unused*/
-static ring writeOrderingAsWP(ring r)
-{
-  assume(r->order[0]==ringorder_wp || r->order[0]==ringorder_dp);
-  if (r->order[0]==ringorder_dp)
-  {
-    ring s = rCopy0(r,FALSE,TRUE);
-    rComplete(s);
-    rTest(s);
-    return s;
-  }
-  return rCopy(r);
-}
-#endif
 
 static ideal constructStartingIdeal(ideal originalIdeal, ring originalRing, number uniformizingParameter, ring startingRing)
 {
@@ -221,10 +224,11 @@ static ideal constructStartingIdeal(ideal originalIdeal, ring originalRing, numb
     J->m[i] = p_PermPoly(originalIdeal->m[i],shiftByOne,originalRing,startingRing,nMap,NULL,0);
   omFreeSize(shiftByOne,(n+1)*sizeof(int));
 
-  ring origin = currRing;
-  rChangeCurrRing(startingRing);
-  ideal startingIdeal = kNF(pt,startingRing->qideal,J);
-  rChangeCurrRing(origin);
+  // ring origin = currRing;
+  // rChangeCurrRing(startingRing);
+  // ideal startingIdeal = kNF(pt,startingRing->qideal,J);
+  // rChangeCurrRing(origin);
+  ideal startingIdeal = J; J = NULL;
   assume(startingIdeal->m[k]==NULL);
   startingIdeal->m[k] = pt->m[0];
   startingIdeal = gfanlib_kStd_wrapper(startingIdeal,startingRing);
@@ -866,11 +870,11 @@ tropicalStrategy::tropicalStrategy():
   originalRing(NULL),
   originalIdeal(NULL),
   expectedDimension(NULL),
-  linealitySpace(gfan::ZCone()), // to come, see below
-  startingRing(NULL),            // to come, see below
-  startingIdeal(NULL),           // to come, see below
-  uniformizingParameter(NULL),   // to come, see below
-  shortcutRing(NULL),            // to come, see below
+  linealitySpace(gfan::ZCone()),
+  startingRing(NULL),
+  startingIdeal(NULL),
+  uniformizingParameter(NULL),
+  shortcutRing(NULL),
   onlyLowerHalfSpace(false)
 {
   weightAdjustingAlgorithm1=NULL;

--- a/Singular/dyn_modules/gfanlib/tropicalVariety.cc
+++ b/Singular/dyn_modules/gfanlib/tropicalVariety.cc
@@ -88,33 +88,33 @@ BOOLEAN tropicalVariety(leftv res, leftv args)
     if (v==NULL)
     {
       setOptionRedSB();
-      ideal stdI;
-      if (!hasFlag(u,FLAG_STD))
-        stdI = gfanlib_kStd_wrapper(I,currRing);
-      else
-        stdI = id_Copy(I,currRing);
+      // ideal stdI;
+      // if (!hasFlag(u,FLAG_STD))
+      //   stdI = gfanlib_kStd_wrapper(I,currRing);
+      // else
+      //   stdI = id_Copy(I,currRing);
       tropicalStrategy currentStrategy(I,currRing);
       gfan::ZFan* tropI = tropicalVariety(currentStrategy);
       res->rtyp = fanID;
       res->data = (char*) tropI;
       undoSetOptionRedSB();
-      id_Delete(&stdI,currRing);
+      // id_Delete(&stdI,currRing);
       return FALSE;
     }
     if ((v!=NULL) && (v->Typ()==NUMBER_CMD))
     {
       number p = (number) v->Data();
-      ideal stdI;
-      if (!hasFlag(u,FLAG_STD))
-        stdI = gfanlib_kStd_wrapper(I,currRing);
-      else
-        stdI = id_Copy(I,currRing);
-      tropicalStrategy currentStrategy(stdI,p,currRing);
-      // tropicalStrategy currentStrategy(I,p,currRing);
+      // ideal stdI;
+      // if (!hasFlag(u,FLAG_STD))
+      //   stdI = gfanlib_kStd_wrapper(I,currRing);
+      // else
+      //   stdI = id_Copy(I,currRing);
+      // tropicalStrategy currentStrategy(stdI,p,currRing);
+      tropicalStrategy currentStrategy(I,p,currRing);
       gfan::ZFan* tropI = tropicalVariety(currentStrategy);
       res->rtyp = fanID;
       res->data = (char*) tropI;
-      id_Delete(&stdI,currRing);
+      // id_Delete(&stdI,currRing);
       return FALSE;
     }
     return FALSE;

--- a/gfanlib/gfanlib_zcone.cpp
+++ b/gfanlib/gfanlib_zcone.cpp
@@ -22,8 +22,8 @@
 #else
 #include <setoper.h>
 #include <cdd.h>
-#endif
-#endif
+#endif //HAVE_CDDLIB_SETOPER_H
+#endif //HAVE_CDD_SETOPER_H
 
 namespace gfan{
 


### PR DESCRIPTION
bbfan.cc
- moved initialization and deletion temp1 outside of loop to avoid unnecessary initializations / deletions
- commented out function coneContaining, as it is not used (and does not work yet)

tropical.cc
- added function "lowerHomogeneitySpace"

tropicalStrategy.cc
- allow users to use dp or ds or ws in basering when calling "tropicalVariety(ideal I)"
- removed unnecessary function
- removed out of place comments
- removed redundant standard bases computation

tropicalVariety.cc
- removed redundant standard bases computation