### PR TITLE
fix warnings in normal.lib

### DIFF
--- a/Singular/LIB/normal.lib
+++ b/Singular/LIB/normal.lib
@@ -4167,10 +4167,11 @@ static proc computeRing(ideal J, ideal I, list #)
     setring R1;
     ideal norid = imap(R, I);
     ideal normap = imap(R, maxid);
-    export norid;
-    export normap;
+
 
     if(noRed == 1){
+      export norid;
+      export normap;
       setring R;
       return(R1);
     }
@@ -6697,7 +6698,7 @@ EXAMPLE: example norTest; shows an example
     LR[3] = newg3;
 //LR;"";
     def newR = ring(LR);
-
+    kill LR; //otherwise it keeps defined and will cause a warning next time norTest is run.
     setring newR;
     ideal norid = fetch(R,norid);
     ideal normap = fetch(R,normap);


### PR DESCRIPTION
add a test if you like:
```
LIB("normal.lib");

// test wrapped in a routine tu suppress output.
proc testRedefineInNormalP()
{
 ring rng = (3),(xx,yy,zz),(dp(2),dp(1),C);
 ideal J = xx^2*yy*zz-yy^2*zz^2;
 intvec v=1,1,1;
 ideal component = xx^2-yy*zz;
 def L1 = normalP(component,"withRing");
 intvec w = norTest(component, L1);
 ASSUME(0, v == norTest(component, L1) );
}

testRedefineInNormalP();
```