### PR TITLE
fix: memleak in nlInitMPZ

### DIFF
--- a/libpolys/coeffs/longrat.cc
+++ b/libpolys/coeffs/longrat.cc
@@ -2567,7 +2567,6 @@ static number nlInitMPZ(mpz_t m, const coeffs)
 {
   number z = ALLOC_RNUMBER();
   mpz_init_set(z->z, m);
-  mpz_init_set_ui(z->n, 1);
   z->s = 3;
   return z;
 }


### PR DESCRIPTION
setting "z->s = 3" represents that "z->n" is unitialized and hence it is ignored in the destructor.