### PR TITLE
chg: added note for using liftstd in quotient rings

### DIFF
--- a/doc/reference.doc
+++ b/doc/reference.doc
@@ -3747,6 +3747,8 @@ basis returned by @code{liftstd}, and @code{T} the transformation matrix
 then @code{matrix(sm)=matrix(m)*T} and @code{sm=ideal(matrix(m)*T)},
 resp.@: @code{sm=module(matrix(m)*T)}.
 @*In an optional third argument the syzygy module will be returned.
+@item @strong{Note:}
+if working in a quotient ring, then @code{matrix(sm)=reduce(matrix(m)*T,0)} and @code{sm=reduce(ideal(matrix(m)*T),0)}.
 @item @strong{Example:}
 @smallexample
 @c example


### PR DESCRIPTION
Hallo Hans, Oleksandr,

könnt ihr mal schauen, ob das, was ich geschrieben habe stimmt? Ich bin darüber gestolpert, als ich versucht habe, Gröbnerbasen zu liften. Das Beispiel ist folgendes:

ring r = (0,z),(Y(1),Y(2),y),(c,dp(2),dp(1));
qring q = std(y^4-z^4);
module H = [y^2-1,(z^2-1)],[Y(1)*y,(z)*Y(2)],[(z)*Y(1)-Y(2)*y],[0,(z)*Y(1)-Y(2)*y];
matrix Q;
module Hdash = liftstd(H,Q);
print(Hdash);
print(reduce(matrix(H)*Q,0));

beste Grüße, Yue.