### PR TITLE
chg: removed redundant std warning

### DIFF
--- a/Singular/iparith.cc
+++ b/Singular/iparith.cc
@@ -3055,7 +3055,8 @@ static BOOLEAN jjREAD2(leftv res, leftv u, leftv v)
 }
 static BOOLEAN jjREDUCE_P(leftv res, leftv u, leftv v)
 {
-  assumeStdFlag(v);
+  if (currRing->qideal!=NULL)
+    assumeStdFlag(v);
   res->data = (char *)kNF((ideal)v->Data(),currRing->qideal,(poly)u->Data());
   return FALSE;
 }


### PR DESCRIPTION
removed std warning when reducing with respect to a polynomial if the basering is no quotient ring