### PR TITLE
fix for zz is number warning

### DIFF
--- a/Singular/LIB/primdec.lib
+++ b/Singular/LIB/primdec.lib
@@ -873,7 +873,7 @@ EXAMPLE: example zero_decomp; shows an example
   def   @P = basering;
   int uytrewq;
   int nva = nvars(basering);
-  int @k,@s,@n,@k1,zz;
+  int @k,@s,@n,@k1,@zz;
   list primary,lres0,lres1,act,@lh,@wh;
   map phi,psi,phi1,psi1;
   ideal jmap,jmap1,jmap2,helpprim,@qh,@qht,ser1;
@@ -1054,10 +1054,10 @@ EXAMPLE: example zero_decomp; shows an example
   if((npars(basering)>0)&&(voice>=9))
   {
     poly randp;
-    for(zz=1;zz<nvars(basering);zz++)
+    for(@zz=1;@zz<nvars(basering);@zz++)
     {
       randp=randp
-              +(random(0,5)*par(1)^2+random(0,5)*par(1)+random(0,5))*var(zz);
+              +(random(0,5)*par(1)^2+random(0,5)*par(1)+random(0,5))*var(@zz);
     }
     randp=randp+var(nvars(basering));
   }
@@ -1067,10 +1067,10 @@ EXAMPLE: example zero_decomp; shows an example
     @k++;
     if (size(primary[2*@k])==0)
     {
-      for(zz=1;zz<size(primary[2*@k-1])-1;zz++)
+      for(@zz=1;@zz<size(primary[2*@k-1])-1;@zz++)
       {
         attrib(primary[2*@k-1],"isSB",1);
-        if(vdim(primary[2*@k-1])==deg(primary[2*@k-1][zz]))
+        if(vdim(primary[2*@k-1])==deg(primary[2*@k-1][@zz]))
         {
           primary[2*@k]=primary[2*@k-1];
         }
@@ -1098,14 +1098,14 @@ EXAMPLE: example zero_decomp; shows an example
       {
         if(deg(lead(primary[2*@k-1][@n]))==1)
         {
-          for(zz=1;zz<=nva;zz++)
+          for(@zz=1;@zz<=nva;@zz++)
           {
-            if(lead(primary[2*@k-1][@n])/var(zz)!=0)
+            if(lead(primary[2*@k-1][@n])/var(@zz)!=0)
             {
-              jmap1[zz]=-1/leadcoef(primary[2*@k-1][@n])*primary[2*@k-1][@n]
+              jmap1[@zz]=-1/leadcoef(primary[2*@k-1][@n])*primary[2*@k-1][@n]
                    +2/leadcoef(primary[2*@k-1][@n])*lead(primary[2*@k-1][@n]);
-              jmap2[zz]=primary[2*@k-1][@n];
-              @qht[@n]=var(zz);
+              jmap2[@zz]=primary[2*@k-1][@n];
+              @qht[@n]=var(@zz);
             }
           }
           jmap[nva]=subst(jmap[nva],lead(primary[2*@k-1][@n]),0);
@@ -9022,7 +9022,7 @@ EXAMPLE: example newZero_decomp; shows an example
   def   @P = basering;
   int uytrewq;
   int nva = nvars(basering);
-  int @k,@s,@n,@k1,zz;
+  int @k,@s,@n,@k1,@zz;
   list primary,lres0,lres1,act,@lh,@wh;
   map phi,psi,phi1,psi1;
   ideal jmap,jmap1,jmap2,helpprim,@qh,@qht,ser1;
@@ -9205,10 +9205,10 @@ EXAMPLE: example newZero_decomp; shows an example
   if((npars(basering)>0)&&(nestLevel > 1))
   {
     poly randp;
-    for(zz=1;zz<nvars(basering);zz++)
+    for(@zz=1;@zz<nvars(basering);@zz++)
     {
       randp=randp
-              +(random(0,5)*par(1)^2+random(0,5)*par(1)+random(0,5))*var(zz);
+              +(random(0,5)*par(1)^2+random(0,5)*par(1)+random(0,5))*var(@zz);
     }
     randp=randp+var(nvars(basering));
   }
@@ -9218,10 +9218,10 @@ EXAMPLE: example newZero_decomp; shows an example
     @k++;
     if (size(primary[2*@k])==0)
     {
-      for(zz=1;zz<size(primary[2*@k-1])-1;zz++)
+      for(@zz=1;@zz<size(primary[2*@k-1])-1;@zz++)
       {
         attrib(primary[2*@k-1],"isSB",1);
-        if(vdim(primary[2*@k-1])==deg(primary[2*@k-1][zz]))
+        if(vdim(primary[2*@k-1])==deg(primary[2*@k-1][@zz]))
         {
           primary[2*@k]=primary[2*@k-1];
         }
@@ -9249,14 +9249,14 @@ EXAMPLE: example newZero_decomp; shows an example
       {
         if(deg(lead(primary[2*@k-1][@n]))==1)
         {
-          for(zz=1;zz<=nva;zz++)
+          for(@zz=1;@zz<=nva;@zz++)
           {
-            if(lead(primary[2*@k-1][@n])/var(zz)!=0)
+            if(lead(primary[2*@k-1][@n])/var(@zz)!=0)
             {
-              jmap1[zz]=-1/leadcoef(primary[2*@k-1][@n])*primary[2*@k-1][@n]
+              jmap1[@zz]=-1/leadcoef(primary[2*@k-1][@n])*primary[2*@k-1][@n]
                    +2/leadcoef(primary[2*@k-1][@n])*lead(primary[2*@k-1][@n]);
-              jmap2[zz]=primary[2*@k-1][@n];
-              @qht[@n]=var(zz);
+              jmap2[@zz]=primary[2*@k-1][@n];
+              @qht[@n]=var(@zz);
             }
           }
           jmap[nva]=subst(jmap[nva],lead(primary[2*@k-1][@n]),0);


### PR DESCRIPTION
'`zz` is ..'- warning causes problems for me in testing (others are ok)
It would be nice if this change could be merged in.
Thanks,

Jakob
```
LIB("primdec.lib");
ring R = (0),(x,y,z),lp;
ideal I = -197*y^2*z^2+67;
option(warn);
minAssGTZ(I);
// ** `zz` is poly in primdec.lib::newZero_decomp:9025:  int @k,@s,@n,@k1,zz;


ring S = (19,vv),(x,y,z),lp;
minpoly = (vv^2+6*vv-4);
ideal I = (5*vv-4)*y;
option(warn);
primdecGTZ(I);
// ** `zz` is number in primdec.lib::zero_decomp:876:  int @k,@s,@n,@k1,zz;
```
