### PR TITLE
neutralize: tests for Singular/dyn_modules/syzextra

### DIFF
--- a/Singular/dyn_modules/syzextra/Makefile.am
+++ b/Singular/dyn_modules/syzextra/Makefile.am
@@ -22,15 +22,15 @@ syzextra_la_SOURCES   = $(SOURCES)
 syzextra_la_CPPFLAGS  = ${MYINCLUDES} ${P_PROCS_CPPFLAGS_COMMON}
 syzextra_la_LDFLAGS   = ${AM_LDFLAGS} ${P_PROCS_MODULE_LDFLAGS} ${GOOGLE_PERFTOOL_LDFLAGS}
 
-AM_COLOR_TESTS=always
-
-TESTS_ENVIRONMENT  = SINGULARPATH='${abs_top_builddir}/Singular/LIB:${abs_top_srcdir}/Singular/LIB:${abs_top_builddir}/libpolys/polys/.libs:${abs_top_builddir}/factory/gftables:${abs_builddir}/.libs:${abs_srcdir}'
-TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
-TESTS_ENVIRONMENT += SINGULAR_BIN_DIR='${abs_top_builddir}/Singular'
-
-TESTS=test_release.sh
-
-EXTRA_DIST = test.sh $(TESTS)
-# syzextra.tst ederc.tst test_clear_enum.tst
-
-CLEANFILES = SimpleTests.json
+# AM_COLOR_TESTS=always
+#
+# TESTS_ENVIRONMENT  = SINGULARPATH='${abs_top_builddir}/Singular/LIB:${abs_top_srcdir}/Singular/LIB:${abs_top_builddir}/libpolys/polys/.libs:${abs_top_builddir}/factory/gftables:${abs_builddir}/.libs:${abs_srcdir}'
+# TESTS_ENVIRONMENT += SINGULAR_ROOT_DIR='${abs_top_builddir}'
+# TESTS_ENVIRONMENT += SINGULAR_BIN_DIR='${abs_top_builddir}/Singular'
+#
+# TESTS=test_release.sh
+#
+# EXTRA_DIST = test.sh $(TESTS)
+# # syzextra.tst ederc.tst test_clear_enum.tst
+#
+# CLEANFILES = SimpleTests.json


### PR DESCRIPTION
It appears that the test scripts for Singular/dyn_modules/syzextra are not present in the last source ball 4.0.2p2: this patch neutralizes them from the Makefile.am itself.