### PR TITLE
tests: omalloc: getlucky

### DIFF
--- a/omalloc/Makefile.am
+++ b/omalloc/Makefile.am
@@ -60,9 +60,11 @@ DISTCLEANFILES = omConfig.h
 ####################################################
 ## Test program
 
-TESTS = omtTest-m omtTest-r
+TESTS = getlucky-omtTest-m getlucky-omtTest-r
 
-check_PROGRAMS = $(TESTS)
+check_PROGRAMS = omtTest-m omtTest-r
+
+check_SCRIPTS = $(TESTS)
 
 # EXTRA_PROGRAMS = omtTest-r
 
@@ -78,3 +80,12 @@ omtTest_r_LDADD    = libomalloc.la
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = omalloc.pc
 
+getlucky-omtTest-m: getlucky-omtTest-X.sh
+	$(LN_S) $< $@
+
+getlucky-omtTest-r: getlucky-omtTest-X.sh
+	$(LN_S) $< $@
+
+CLEANFILES += $(TESTS)
+
+EXTRA_DIST = getlucky-omtTest-X.sh

--- a/omalloc/getlucky-omtTest-X.sh
+++ b/omalloc/getlucky-omtTest-X.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+##
+## comment:
+##  omalloc testing/verification may oversee some memory error in some random cases:
+##  this simple wrapper is meant to work around those unlucky cases by running a few
+##  number of tests instead of just one test.
+##
+SCRIPTNAME=${0##*/}
+CHECK_PROGRAM=${SCRIPTNAME#getlucky-}
+NUMBEROF_TRIAL=11
+for idx in $(seq 1 $NUMBEROF_TRIAL); do
+	./$CHECK_PROGRAM && { echo "$SCRIPTNAME: SUMMARY: $idx trial(s)" ; exit 0 ; }
+done
+echo "$SCRIPTNAME: SUMMARY: $idx failed trials"
+exit 1
+# eos


### PR DESCRIPTION
omalloc testing/verification may oversee some memory error in some random cases:
this patch introduces a simple wrapper that is meant to work around those unlucky cases by running a few number of tests instead of just one test.