### PR TITLE
fix: forgotten libgfan.so during installation

### DIFF
--- a/gfanlib/Makefile.am
+++ b/gfanlib/Makefile.am
@@ -17,3 +17,4 @@ libgfan_include_HEADERS = gfanlib_z.h gfanlib_q.h gfanlib_vector.h gfanlib_matri
 
 DISTCLEANFILES =  config.h
 
+moduledir = $(libexecdir)/singular/MOD


### PR DESCRIPTION
fixes gfanlib.so load problems because of missing libgfan.so in /usr/local/libexec/singular/MOD/