### PR TITLE
factory: make Prem public

### DIFF
--- a/factory/cfCharSetsUtil.h
+++ b/factory/cfCharSetsUtil.h
@@ -69,8 +69,12 @@ sortListCFList (ListCFList& list);
 void
 sortCFListByLevel (CFList& list);
 
+/*BEGINPUBLIC*/
+
 CanonicalForm
 Prem (const CanonicalForm& F, const CanonicalForm& G);
+
+/*ENDPUBLIC*/
 
 CanonicalForm
 Premb (const CanonicalForm &f, const CFList &L);


### PR DESCRIPTION
It is used by Macaulay2.  Currently, factory is patched so that Prem is
public [1] and built from source by the M2 build system.  However, if
factory already exists on the system, it would be nice to be able to use it
(see [2]).

[1] https://github.com/Macaulay2/M2/blob/4af5a55/M2/libraries/factory/patch-4.0.2
[2] https://github.com/Macaulay2/M2/issues/384