### PR TITLE
reproducible: __DATE__ and __TIME__ : discard

### DIFF
--- a/Singular/emacs.cc
+++ b/Singular/emacs.cc
@@ -89,7 +89,7 @@ void fePrintReportBug(char* msg, char* file, int line)
 "Please, email the following output to singular@mathematik.uni-kl.de\n"
 "Bug occurred at %s:%d\n"
 "Message: %s\n"
-"Version: " S_UNAME VERSION __DATE__ __TIME__,
+"Version: " S_UNAME VERSION VERSION_DATE,
         file, line, msg);
 
 }

--- a/Singular/misc_ip.cc
+++ b/Singular/misc_ip.cc
@@ -780,7 +780,7 @@ char * versionString(/*const bool bShowDetails = false*/ )
   StringSetS("");
   StringAppend("Singular for %s version %s (%d, %d bit) %s #%s",
                S_UNAME, VERSION, // SINGULAR_VERSION,
-               SINGULAR_VERSION, SIZEOF_VOIDP*8, singular_date, GIT_VERSION);
+               SINGULAR_VERSION, SIZEOF_VOIDP*8, VERSION_DATE, GIT_VERSION);
   StringAppendS("\nwith\n\t");
 
 #if defined(mpir_version)
@@ -1154,8 +1154,6 @@ void m2_end(int i)
   }
 }
 }
-
-const char *singular_date=__DATE__ " " __TIME__;
 
 extern "C"
 {


### PR DESCRIPTION
Attempt to render the upstream source reproducible:
https://wiki.debian.org/ReproducibleBuilds/TimestampsFromCPPMacros