### PR TITLE
fixes target vector setting in grwalk, rwalk, and swalk if target ordering is (a(w),lp)

### DIFF
--- a/Singular/LIB/grwalk.lib
+++ b/Singular/LIB/grwalk.lib
@@ -35,6 +35,12 @@ static proc OrderStringalp_NP(string Wpal,list #)
   intvec curr_weight = system("Mivdp",n); //define (1,1,...,1)
   intvec target_weight = system("Mivlp",n); //define (1,0,...,0)
 
+  // check if the target ring has a weighted lp ordering
+  list rl = ringlist(basering);
+  if (rl[3][1][1] == "a" and rl[3][2][1] == "lp") {
+    target_weight = rl[3][1][2];
+  }
+
   if(size(#) != 0)
   {
     if(size(#) == 1)

--- a/Singular/LIB/rwalk.lib
+++ b/Singular/LIB/rwalk.lib
@@ -31,6 +31,12 @@ static proc OrderStringalp_NP(string Wpal,list #)
   intvec curr_weight = system("Mivdp",n); //define (1,1,...,1)
   intvec target_weight = system("Mivlp",n); //define (1,0,...,0)
 
+  // check if the target ring has a weighted lp ordering
+  list rl = ringlist(basering);
+  if (rl[3][1][1] == "a" and rl[3][2][1] == "lp") {
+    target_weight = rl[3][1][2];
+  }
+
   if(size(#) != 0)
   {
     if(size(#) == 1)

--- a/Singular/LIB/swalk.lib
+++ b/Singular/LIB/swalk.lib
@@ -473,6 +473,12 @@ static proc OrderStringalp(string Wpal,list #)
   curr_weight = system("Mivdp",n);
   target_weight = system("Mivlp",n);
 
+  // check if the target ring has a weighted lp ordering
+  list rl = ringlist(basering);
+  if (rl[3][1][1] == "a" and rl[3][2][1] == "lp") {
+    target_weight = rl[3][1][2];
+  }
+
    if(size(#) != 0)
    {
      if(size(#) == 1)
@@ -557,6 +563,13 @@ static proc OrderStringalp_NP(string Wpal,list #)
   int nP = 1;// call LatsGB to compute the wanted GB  by pwalk
   intvec curr_weight = system("Mivdp",n); //define (1,1,...,1)
   intvec target_weight = system("Mivlp",n); //define (1,0,...,0)
+
+  // check if the target ring has a weighted lp ordering
+  list rl = ringlist(basering);
+  if (rl[3][1][1] == "a" and rl[3][2][1] == "lp") {
+    target_weight = rl[3][1][2];
+  }
+
   if(size(#) != 0)
   {
     if(size(#) == 1)


### PR DESCRIPTION
Note: Fix for trac ticket #772