### PR TITLE
always autoconfigure xalloc folder

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,7 @@ AC_CONFIG_FILES([dox/Makefile])
 
 AC_CONFIG_SUBDIRS([resources])
 AC_CONFIG_SUBDIRS([omalloc])
+AC_CONFIG_SUBDIRS([xalloc])
 
 if test "x$ENABLE_FACTORY" = xyes; then
  AC_CONFIG_SUBDIRS([factory])


### PR DESCRIPTION
Den xalloc-Ordner immer autokonfigurieren, so dass Sage  kein repackaging durchführen muss.

Am besten wäre naturlich, wenn Singular den Buildvorgang so anpassen könnte, dass man 
z.B. mit einer configure-optiion `--enable-xalloc` omalloc durch xalloc ersetzen kann (für den debug-Modus)
