### PR TITLE
fix: added missing gfan.lib in singular-libs

### DIFF
--- a/Singular/singular-libs
+++ b/Singular/singular-libs
@@ -42,7 +42,7 @@ SLIB1 = classifyceq.lib classifyci.lib classify_aeq.lib \
         dmodloc.lib divisors.lib \
         ffsolve.lib ffmodstd.lib decomp.lib template.lib \
         findifs.lib finitediff.lib \
-        gitfan.lib gradedModules.lib \
+        gfan.lib gitfan.lib gradedModules.lib \
         locnormal.lib modnormal.lib modular.lib \
 	JMBTest.lib JMSConst.lib multigrading.lib \
 	nfmodstd.lib nfmodsyz.lib \


### PR DESCRIPTION
Hab rausgefunden, warum gfan.lib bei "make install" nicht kopiert wird!
