### PR TITLE
correct spelling errors as detected by Lintian

### DIFF
--- a/kernel/combinatorics/hilb.cc
+++ b/kernel/combinatorics/hilb.cc
@@ -79,7 +79,7 @@ static void hHilbEst(scfmon stc, int Nstc, varset var, int Nvar)
     {
       if (z>(MAX_INT_VAL)/2)
       {
-       WerrorS("interal arrays too big");
+       WerrorS("internal arrays too big");
        return;
       }
       p = (int *)omAlloc((unsigned long)z * sizeof(int));


### PR DESCRIPTION
Description: source typo
 Correct spelling error as reported by lintian in some binraries; meant to silence lintian.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2016-11-09
