### PR TITLE
fix: memoryleak due to missing deallocation of cddlib global variables

### DIFF
--- a/Singular/dyn_modules/gfanlib/bbcone.cc
+++ b/Singular/dyn_modules/gfanlib/bbcone.cc
@@ -352,6 +352,7 @@ static BOOLEAN jjCONENORMALS3(leftv res, leftv u, leftv v, leftv w)
 
 BOOLEAN coneViaNormals(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && ((u->Typ() == BIGINTMAT_CMD) || (u->Typ() == INTMAT_CMD)))
@@ -508,6 +509,7 @@ static BOOLEAN jjCONERAYS3(leftv res, leftv u, leftv v, leftv w)
 
 BOOLEAN coneViaRays(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && ((u->Typ() == BIGINTMAT_CMD) || (u->Typ() == INTMAT_CMD)))
@@ -530,6 +532,7 @@ BOOLEAN coneViaRays(leftv res, leftv args)
 
 BOOLEAN inequalities(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID || u->Typ() == polytopeID))
@@ -547,6 +550,7 @@ BOOLEAN inequalities(leftv res, leftv args)
 
 BOOLEAN equations(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID || u->Typ() == polytopeID))
@@ -563,6 +567,7 @@ BOOLEAN equations(leftv res, leftv args)
 
 BOOLEAN facets(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID || u->Typ() == polytopeID))
@@ -579,6 +584,7 @@ BOOLEAN facets(leftv res, leftv args)
 
 BOOLEAN impliedEquations(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID || u->Typ() == polytopeID))
@@ -595,6 +601,7 @@ BOOLEAN impliedEquations(leftv res, leftv args)
 
 BOOLEAN generatorsOfSpan(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID || u->Typ() == polytopeID))
@@ -611,6 +618,7 @@ BOOLEAN generatorsOfSpan(leftv res, leftv args)
 
 BOOLEAN generatorsOfLinealitySpace(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID || u->Typ() == polytopeID))
@@ -627,6 +635,7 @@ BOOLEAN generatorsOfLinealitySpace(leftv res, leftv args)
 
 BOOLEAN rays(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -651,6 +660,7 @@ BOOLEAN rays(leftv res, leftv args)
 
 BOOLEAN quotientLatticeBasis(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -667,6 +677,7 @@ BOOLEAN quotientLatticeBasis(leftv res, leftv args)
 
 BOOLEAN getLinearForms(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -683,6 +694,7 @@ BOOLEAN getLinearForms(leftv res, leftv args)
 
 BOOLEAN ambientDimension(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -712,6 +724,7 @@ BOOLEAN ambientDimension(leftv res, leftv args)
 
 BOOLEAN dimension(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -741,6 +754,7 @@ BOOLEAN dimension(leftv res, leftv args)
 
 BOOLEAN codimension(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -770,6 +784,7 @@ BOOLEAN codimension(leftv res, leftv args)
 
 BOOLEAN linealityDimension(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -792,6 +807,7 @@ BOOLEAN linealityDimension(leftv res, leftv args)
 
 BOOLEAN getMultiplicity(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -808,6 +824,7 @@ BOOLEAN getMultiplicity(leftv res, leftv args)
 
 BOOLEAN isOrigin(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -824,6 +841,7 @@ BOOLEAN isOrigin(leftv res, leftv args)
 
 BOOLEAN isFullSpace(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -840,6 +858,7 @@ BOOLEAN isFullSpace(leftv res, leftv args)
 
 BOOLEAN isSimplicial(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -864,6 +883,7 @@ BOOLEAN isSimplicial(leftv res, leftv args)
 
 BOOLEAN containsPositiveVector(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -880,6 +900,7 @@ BOOLEAN containsPositiveVector(leftv res, leftv args)
 
 BOOLEAN linealitySpace(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -896,6 +917,7 @@ BOOLEAN linealitySpace(leftv res, leftv args)
 
 BOOLEAN dualCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -912,6 +934,7 @@ BOOLEAN dualCone(leftv res, leftv args)
 
 BOOLEAN negatedCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -928,6 +951,7 @@ BOOLEAN negatedCone(leftv res, leftv args)
 
 BOOLEAN semigroupGenerator(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -951,6 +975,7 @@ BOOLEAN semigroupGenerator(leftv res, leftv args)
 
 BOOLEAN relativeInteriorPoint(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -967,6 +992,7 @@ BOOLEAN relativeInteriorPoint(leftv res, leftv args)
 
 BOOLEAN uniquePoint(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1004,6 +1030,7 @@ gfan::ZVector randomPoint(const gfan::ZCone* zc)
 
 BOOLEAN randomPoint(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1020,6 +1047,7 @@ BOOLEAN randomPoint(leftv res, leftv args)
 
 BOOLEAN setMultiplicity(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1041,6 +1069,7 @@ BOOLEAN setMultiplicity(leftv res, leftv args)
 
 BOOLEAN setLinearForms(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1094,6 +1123,7 @@ gfan::ZCone liftUp(const gfan::ZCone &zc)
 
 BOOLEAN coneToPolytope(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1112,6 +1142,7 @@ BOOLEAN coneToPolytope(leftv res, leftv args)
 
 BOOLEAN intersectCones(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1202,6 +1233,7 @@ BOOLEAN intersectCones(leftv res, leftv args)
 
 BOOLEAN convexHull(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1309,6 +1341,7 @@ BOOLEAN convexHull(leftv res, leftv args)
 
 BOOLEAN coneLink(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1355,6 +1388,7 @@ BOOLEAN coneLink(leftv res, leftv args)
 
 BOOLEAN containsInSupport(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1414,6 +1448,7 @@ BOOLEAN containsInSupport(leftv res, leftv args)
 
 BOOLEAN containsRelatively(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1456,6 +1491,7 @@ BOOLEAN containsRelatively(leftv res, leftv args)
 
 BOOLEAN hasFace(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1490,6 +1526,7 @@ BOOLEAN hasFace(leftv res, leftv args)
 
 BOOLEAN canonicalizeCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == coneID))
@@ -1507,6 +1544,7 @@ BOOLEAN canonicalizeCone(leftv res, leftv args)
 
 BOOLEAN containsCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == LIST_CMD))
@@ -1544,6 +1582,7 @@ BOOLEAN containsCone(leftv res, leftv args)
 
 BOOLEAN faceContaining(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == coneID))

--- a/Singular/dyn_modules/gfanlib/bbfan.cc
+++ b/Singular/dyn_modules/gfanlib/bbfan.cc
@@ -38,6 +38,7 @@ char* bbfan_String(blackbox* /*b*/, void *d)
   if (d==NULL) return omStrDup("invalid object");
   else
   {
+    gfan::deinitializeCddlibIfRequired();
     gfan::initializeCddlibIfRequired();
     gfan::ZFan* zf = (gfan::ZFan*)d;
     std::string s = zf->toString(2+4+8+128);
@@ -175,6 +176,7 @@ static BOOLEAN jjFANEMPTY_IM(leftv res, leftv v)
 
 BOOLEAN emptyFan(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if (u == NULL)
@@ -228,6 +230,7 @@ static BOOLEAN jjFANFULL_IM(leftv res, leftv v)
 
 BOOLEAN fullFan(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if (u == NULL)
@@ -266,6 +269,7 @@ int getLinealityDimension(gfan::ZFan* zf)
 
 BOOLEAN numberOfConesOfDimension(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -311,6 +315,7 @@ BOOLEAN numberOfConesOfDimension(leftv res, leftv args)
 
 BOOLEAN ncones(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -332,6 +337,7 @@ BOOLEAN ncones(leftv res, leftv args)
 
 BOOLEAN nmaxcones(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -371,6 +377,7 @@ bool isCompatible(const gfan::ZFan* zf, const gfan::ZCone* zc)
 
 BOOLEAN isCompatible(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -392,6 +399,7 @@ BOOLEAN isCompatible(leftv res, leftv args)
 
 BOOLEAN insertCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->rtyp==IDHDL) && (u->e==NULL) && (u->Typ() == fanID))
@@ -450,6 +458,7 @@ bool containsInCollection(gfan::ZFan* zf, gfan::ZCone* zc)
 
 BOOLEAN containsInCollection(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -509,6 +518,7 @@ BOOLEAN containsInCollection(leftv res, leftv args)
 
 BOOLEAN removeCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -546,6 +556,7 @@ BOOLEAN removeCone(leftv res, leftv args)
 
 BOOLEAN getCone(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -622,6 +633,7 @@ BOOLEAN getCone(leftv res, leftv args)
 
 BOOLEAN getCones(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -697,6 +709,7 @@ int isSimplicial(gfan::ZFan* zf)
 
 BOOLEAN isPure(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -728,6 +741,7 @@ BOOLEAN isPure(leftv res, leftv args)
 
 BOOLEAN fVector(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -744,6 +758,7 @@ BOOLEAN fVector(leftv res, leftv args)
 
 gfan::ZMatrix rays(const gfan::ZFan* const zf)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   gfan::ZMatrix rays(0,zf->getAmbientDimension());
   for (int i=0; i<zf->numberOfConesOfDimension(1,0,0); i++)
@@ -756,6 +771,7 @@ gfan::ZMatrix rays(const gfan::ZFan* const zf)
 
 int numberOfConesWithVector(gfan::ZFan* zf, gfan::ZVector* v)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   int count = 0;
   int ambientDim = zf->getAmbientDimension();
@@ -774,6 +790,7 @@ int numberOfConesWithVector(gfan::ZFan* zf, gfan::ZVector* v)
 
 BOOLEAN numberOfConesWithVector(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))
@@ -803,6 +820,7 @@ BOOLEAN numberOfConesWithVector(leftv res, leftv args)
 
 BOOLEAN fanFromString(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == STRING_CMD))
@@ -820,6 +838,7 @@ BOOLEAN fanFromString(leftv res, leftv args)
 
 BOOLEAN fanViaCones(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == LIST_CMD))
@@ -971,6 +990,7 @@ gfan::ZFan commonRefinement(gfan::ZFan zf, gfan::ZFan zg)
 
 BOOLEAN commonRefinement(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u=args;
   if ((u != NULL) && (u->Typ() == fanID))

--- a/Singular/dyn_modules/gfanlib/bbpolytope.cc
+++ b/Singular/dyn_modules/gfanlib/bbpolytope.cc
@@ -184,6 +184,7 @@ static BOOLEAN ppCONERAYS3(leftv res, leftv u, leftv v)
 
 BOOLEAN polytopeViaVertices(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && ((u->Typ() == BIGINTMAT_CMD) || (u->Typ() == INTMAT_CMD)))
@@ -319,6 +320,7 @@ static BOOLEAN ppCONENORMALS3(leftv res, leftv u, leftv v, leftv w)
 
 BOOLEAN polytopeViaNormals(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && ((u->Typ() == BIGINTMAT_CMD) || (u->Typ() == INTMAT_CMD)))
@@ -341,6 +343,7 @@ BOOLEAN polytopeViaNormals(leftv res, leftv args)
 
 BOOLEAN vertices(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == polytopeID))
@@ -400,6 +403,7 @@ gfan::ZCone newtonPolytope(poly p, ring r)
 
 BOOLEAN newtonPolytope(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == POLY_CMD))
@@ -415,6 +419,7 @@ BOOLEAN newtonPolytope(leftv res, leftv args)
 
 BOOLEAN scalePolytope(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == INT_CMD))
@@ -441,6 +446,7 @@ BOOLEAN scalePolytope(leftv res, leftv args)
 
 BOOLEAN dualPolytope(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == polytopeID))
@@ -457,6 +463,7 @@ BOOLEAN dualPolytope(leftv res, leftv args)
 
 BOOLEAN mixedVolume(leftv res, leftv args)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   leftv u = args;
   if ((u != NULL) && (u->Typ() == LIST_CMD))

--- a/Singular/dyn_modules/gfanlib/gfanlib.cc
+++ b/Singular/dyn_modules/gfanlib/gfanlib.cc
@@ -19,6 +19,7 @@ template class gfan::Matrix<gfan::Rational>;
 
 extern "C" int SI_MOD_INIT(gfanlib)(SModulFunctions* p)
 {
+  gfan::deinitializeCddlibIfRequired();
   gfan::initializeCddlibIfRequired();
   bbcone_setup(p);
   bbfan_setup(p);


### PR DESCRIPTION
Hallo Hans,

der commit behebt ein Speicherleck durch das wiederholte aufrufen von gfan::initializeCddlibIfRequired() (das "IfRequired" im Name ist reiner Betrug :<).

Habe mich vor dem commit vergewissert, dass wiederholtes Aufrufen von gfan::deinitializeCddlibIfRequired() (auch ohne zwischendrinn cddlib zu initialisieren) zu keinen Problemen / Speicherlecks führt.