### PR TITLE
fix one error for sage in debug mode, see https://trac.sagemath.org/t…

### DIFF
--- a/Singular/LIB/normal.lib
+++ b/Singular/LIB/normal.lib
@@ -2724,9 +2724,8 @@ EXAMPLE: example deltaLoc;  shows an example
       poly p=beta(p);
 
       execute("ring C=("+charstr(S)+",a),(x,y),ds;");
-      number p=number(imap(B,p));
 
-      minpoly=p;
+      minpoly=number(imap(B,p));
       map iota=S,a,a;
       number c=number(iota(c));
       number co=iota(co);


### PR DESCRIPTION
behebt eines der Probleme von 
https://trac.sagemath.org/ticket/21624;
("no minpoly allowed if there are local objects belonging to the basering")
siehe auch 
https://groups.google.com/forum/#!topic/libsingular-devel/tYuWlGOZdWo