### PR TITLE
Fix segfault that occurs when piping to its stdin if not attached to a TTY

### DIFF
--- a/Singular/fevoices.cc
+++ b/Singular/fevoices.cc
@@ -375,7 +375,9 @@ BOOLEAN exitVoice()
       omFree((ADDRESS)currentVoice->buffer);
       currentVoice->buffer=NULL;
     }
-    if ((currentVoice->prev==NULL)&&(currentVoice->sw==BI_file))
+    if ((currentVoice->prev==NULL)
+    &&(currentVoice->sw==BI_file)
+    &&(currentVoice->files!=stdin))
     {
       currentVoice->prev=feInitStdin(currentVoice);
     }

--- a/Singular/fevoices.cc
+++ b/Singular/fevoices.cc
@@ -669,7 +669,7 @@ Voice * feInitStdin(Voice *pp)
   Voice *p = new Voice;
   p->files = stdin;
   p->sw = (isatty(STDIN_FILENO)) ? BI_stdin : BI_file;
-  if ((pp!=NULL) && (pp->files==stdin))
+  if ((pp!=NULL) && (pp->sw==BI_stdin) && (pp->files==stdin))
   {
     p->files=freopen("/dev/tty","r",stdin);
     //stdin=p->files;

--- a/Singular/fevoices.cc
+++ b/Singular/fevoices.cc
@@ -595,7 +595,13 @@ int feReadLine(char* b, int l)
       fseek(currentVoice->files,currentVoice->ftellptr,SEEK_SET);
       s=fgets(currentVoice->buffer+offset,(MAX_FILE_BUFFER-1-sizeof(ADDRESS))-offset,
               currentVoice->files);
-      if (s!=NULL) currentVoice->ftellptr=ftell(currentVoice->files);
+      if (s!=NULL)
+      {
+        currentVoice->ftellptr=ftell(currentVoice->files);
+        // ftell returns -1 for non-seekable streams, such as pipes
+        if (currentVoice->ftellptr<0)
+          currentVoice->ftellptr=0;
+      }
     }
     //else /* BI_buffer */ s==NULL  => return 0
     // done by the default return


### PR DESCRIPTION
From the original bug report at https://trac.sagemath.org/ticket/22690, this is the easiest way I've found to reproduce this issue:

```
$ echo -e '3+3;\n' | setsid Singular/Singular
                     SINGULAR                                 /  Development
 A Computer Algebra System for Polynomial Computations       /   version 4.1.0
                                                           0<
 by: W. Decker, G.-M. Greuel, G. Pfister, H. Schoenemann     \   Nov 2016
FB Mathematik der Universitaet, D-67653 Kaiserslautern        \
// ** executing /home/embray/src/singular/Sources/Singular/LIB/.singularrc
6
Singular : signal 11 (v: 4100):
current line:>><<
Segment fault/Bus error occurred at 7fc06e581640 because of 10206 (r:1490625340)
please inform the authors
trying to restart...
fatal flex scanner internal error--end of buffer missed
```

The main change that fixes the segfault is the one on this line: https://github.com/Singular/Sources/compare/spielwiese...embray:io-errors?expand=1#diff-e6af87fbd4fc928276a4d21e7f152499R380  However, I also fixed a few other small bugs in the logic that I noticed while trying to track down the root cause of the bug.