### PR TITLE
fix: memleak converting gfan::Integer to number

### DIFF
--- a/Singular/dyn_modules/gfanlib/callgfanlib_conversion.cc
+++ b/Singular/dyn_modules/gfanlib/callgfanlib_conversion.cc
@@ -11,14 +11,19 @@ number integerToNumber(const gfan::Integer &I)
   mpz_t i;
   mpz_init(i);
   I.setGmp(i);
+
   long m = 268435456;
+  number j;
   if(mpz_cmp_si(i,m))
   {
     int temp = (int) mpz_get_si(i);
-    return n_Init(temp,coeffs_BIGINT);
+    j = n_Init(temp,coeffs_BIGINT);
   }
   else
-    return n_InitMPZ(i,coeffs_BIGINT);
+    j = n_InitMPZ(i,coeffs_BIGINT);
+
+  mpz_clear(i);
+  return j;
 }
 
 bigintmat* zVectorToBigintmat(const gfan::ZVector &zv)


### PR DESCRIPTION
Pretty sure this is a memory leak, mpz_t i was initialized but never cleared. Code to reproduce memory leak:

LIB "gfanlib.so";
intmat M[4][3]=1,0,0,0,1,0,0,0,1,1,1,1;
cone c = coneViaPoints(M);
for (int i=1; i<=10000; i++)
{
  bigintmat R = rays(c);
  kill R;
  memory(0);
}
