### PR TITLE
link libraries sometimes needed by gethostbyname etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,7 @@ m4_ifval([$3],
 fi[]dnl
 ])])
 
+AX_LIB_SOCKET_NSL
 
 AC_DEFINE_UNQUOTED([CC],"$CC",[CC])
 AC_DEFINE_UNQUOTED([CXX],"$CXX",[CXX])

--- a/m4/ax_lib_socket_nsl.m4
+++ b/m4/ax_lib_socket_nsl.m4
@@ -1,0 +1,40 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_lib_socket_nsl.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_LIB_SOCKET_NSL
+#
+# DESCRIPTION
+#
+#   This macro figures out what libraries are required on this platform to
+#   link sockets programs.
+#
+#   The common cases are not to need any extra libraries, or to need
+#   -lsocket and -lnsl. We need to avoid linking with libnsl unless we need
+#   it, though, since on some OSes where it isn't necessary it will totally
+#   break networking. Unisys also includes gethostbyname() in libsocket but
+#   needs libnsl for socket().
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Russ Allbery <rra@stanford.edu>
+#   Copyright (c) 2008 Stepan Kasal <kasal@ucw.cz>
+#   Copyright (c) 2008 Warren Young <warren@etr-usa.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 7
+
+AU_ALIAS([LIB_SOCKET_NSL], [AX_LIB_SOCKET_NSL])
+AC_DEFUN([AX_LIB_SOCKET_NSL],
+[
+	AC_SEARCH_LIBS([gethostbyname], [nsl])
+	AC_SEARCH_LIBS([socket], [socket], [], [
+		AC_CHECK_LIB([socket], [socket], [LIBS="-lsocket -lnsl $LIBS"],
+		[], [-lnsl])])
+])


### PR DESCRIPTION
On Solaris, in particular, one needs -lsocket -lnsl in the libs
to be linked against. See https://trac.sagemath.org/ticket/24611
This is taken care by this autoconf macro call.