### PR TITLE
templated call to pow() needs std::

### DIFF
--- a/libpolys/coeffs/ffields.cc
+++ b/libpolys/coeffs/ffields.cc
@@ -806,7 +806,7 @@ static BOOLEAN nfCoeffIsEqual (const coeffs r, n_coeffType n, void * parameter)
 {
   if (n==n_GF) {
     GFInfo* p = (GFInfo *)(parameter);
-    int c = pow (p->GFChar, p->GFDegree);
+    int c = std::pow (p->GFChar, p->GFDegree);
     if ((c == r->m_nfCharQ) && (strcmp(n_ParameterNames(r)[0], p->GFPar_name) == 0))
       return TRUE;
   }
@@ -927,7 +927,7 @@ BOOLEAN nfInitChar(coeffs r,  void * parameter)
     return TRUE;
   }
 
-  int c = pow (p->GFChar, p->GFDegree);
+  int c = std::pow (p->GFChar, p->GFDegree);
 
   nfReadTable(c, r);
 


### PR DESCRIPTION
Depending on C++ compiler and STL implementation, this is not guaranteed to work. In particular gcc 5.4 (or newer) on Solaris 11
errors out here. (In C++11 pow lives in namespace std, thus if this is not ensured then all the bets are off).

(normally, an instantiation of `int pow()` will  come from a template in STL, I think).