### PR TITLE
don't do floor(int)

### DIFF
--- a/Singular/walk.cc
+++ b/Singular/walk.cc
@@ -4566,11 +4566,11 @@ static intvec* MWalkRandomNextWeight(ideal G, intvec* orig_M, intvec* target_wei
       {
         if((*next_weight2)[i] < 0)
         {
-          (*next_weight2)[i] = 1 + (*curr_weight)[i] + floor(weight_rad*(*next_weight2)[i]/weight_norm);
+          (*next_weight2)[i] = 1 + (*curr_weight)[i] + weight_rad*(*next_weight2)[i]/weight_norm;
         }
         else
         {
-          (*next_weight2)[i] = (*curr_weight)[i] + floor(weight_rad*(*next_weight2)[i]/weight_norm);
+          (*next_weight2)[i] = (*curr_weight)[i] + weight_rad*(*next_weight2)[i]/weight_norm;
         }
       }
       if(test_w_in_ConeCC(G,next_weight2) == 1)


### PR DESCRIPTION
This is another catch from an attempt to build Singular on Solaris 11,
this time using gcc 5.4.0. It errors out saying

walk.cc:4570:103: error: call of overloaded 'floor(int)' is ambiguous
           (*next_weight2)[i] = 1 + (*curr_weight)[i] + floor(weight_rad*(*next_weight2)[i]/weight_norm);

walk.cc:4574:99: error: call of overloaded 'floor(int)' is ambiguous
           (*next_weight2)[i] = (*curr_weight)[i] + floor(weight_rad*(*next_weight2)[i]/weight_norm);