### PR TITLE
Add missing return statement in ivMaxIdeal() proc from fpadim.lib

### DIFF
--- a/Singular/LIB/fpadim.lib
+++ b/Singular/LIB/fpadim.lib
@@ -2398,7 +2398,7 @@ proc lpMaxIdeal(int d, int donly)
   NOTE: analogous to maxideal(d) in the commutative case
   "
 {
-  ivL2lpI(ivMaxIdeal(d, donly));
+  return(ivL2lpI(ivMaxIdeal(d, donly)));
 }
 example {
   "EXAMPLE:"; echo = 2;

--- a/Singular/LIB/fpadim.lib
+++ b/Singular/LIB/fpadim.lib
@@ -2384,8 +2384,6 @@ example {
   ivMaxIdeal(1,0);
   ivMaxIdeal(2,0);
   ivMaxIdeal(2,1);
-  ivMaxIdeal(4,0);
-  ivMaxIdeal(4,1);
 }
 
 proc lpMaxIdeal(int d, int donly)
@@ -2407,8 +2405,6 @@ example {
   lpMaxIdeal(1,0);
   lpMaxIdeal(2,0);
   lpMaxIdeal(2,1);
-  lpMaxIdeal(4,0);
-  lpMaxIdeal(4,1);
 }
 
 proc monomialBasis(int d, int donly, ideal J)


### PR DESCRIPTION
Also removes some unnecessary examples.