### PR TITLE
correct spelling errors as detected by lintian

### DIFF
--- a/Singular/LIB/arr.lib
+++ b/Singular/LIB/arr.lib
@@ -1339,7 +1339,7 @@ proc arrCoordNormalize(arr A, intvec v)
 RETURN:     [arr]: Arrangement after a coordinate change that transforms the arrangement such that
             after a tranformation x -> Tx + c we have the arrangement has the matrix representation
             [AT^-1|b+AT^-1c] such that [AT^-1]_v = I and [b+AT^-1c]_v = 0;
-NOTE:       algorith performs a base change if H_k is homogenous (i.e. has no)
+NOTE:       algorithm performs a base change if H_k is homogenous (i.e. has no)
             constant term and an affine transformation otherwise
             Ax+b = 0, Transformation x = Ty+c: AT^-1y + AT^-1c + b = 0
             Now we want to have (AT^-1)_v = I and (AT^-1c +b)_v = AT^-1_v*c + b_v = 0

--- a/kernel/ideals.cc
+++ b/kernel/ideals.cc
@@ -539,7 +539,7 @@ ideal idMultSect(resolvente arg, int length, GbVariant alg)
   else
   {
     tempstd=idInit(1,1);
-    Werror("wrong algorith %d for SB",(int)alg);
+    Werror("wrong algorithm %d for SB",(int)alg);
   }
 
   if(syz_ring!=orig_ring)
@@ -714,7 +714,7 @@ static ideal idPrepare (ideal  h1, tHomog hom, int syzcomp, intvec **w, GbVarian
   else
   {
     h3=idInit(1,1);
-    Werror("wrong algorith %d for SB",(int)alg);
+    Werror("wrong algorithm %d for SB",(int)alg);
   }
 
   idDelete(&h2);


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in the binary library; meant
 to silence lintian and eventually to be submitted to the upstream maintainer.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2018-02-24