### PR TITLE
correct spelling errors as detected by lintian

### DIFF
--- a/kernel/ideals.cc
+++ b/kernel/ideals.cc
@@ -1819,7 +1819,7 @@ ideal idElimination (ideal h1,poly delVar,intvec *hilb, GbVariant alg)
   else
   {
     hh=idInit(1,1);
-    Werror("wrong algorith %d for SB",(int)alg);
+    Werror("wrong algorithm %d for SB",(int)alg);
   }
   //SI_RESTORE_OPT1(save1);
   idDelete(&h);


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in the binary library; meant
 to silence lintian and eventually to be submitted to the upstream maintainer.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2018-03-30