### PR TITLE
Add missing <string.h> header

### DIFF
--- a/Singular/feOpt.cc
+++ b/Singular/feOpt.cc
@@ -6,7 +6,7 @@
 */
 
 
-
+#include <string.h>
 
 #include "kernel/mod2.h"
 


### PR DESCRIPTION
The code uses `strcmp()` so `<string.h>` should be included.

This is causing compilation failures with `--disable-malloc`.