### PR TITLE
Groebner basis implementation over Z

### DIFF
--- a/kernel/GBEngine/kspoly.cc
+++ b/kernel/GBEngine/kspoly.cc
@@ -214,7 +214,7 @@ int ksReducePolyLC(LObject* PR,
     // for the time being: we know currRing==strat->tailRing
     // no exp-bound checking needed
     // (only needed if exp-bound(tailring)<exp-b(currRing))
-    if (PR->bucket!=NULL)  nc_kBucketPolyRed(PR->bucket, p2,coef);
+    if (PR->bucket!=NULL)  nc_kBucketPolyRed_Z(PR->bucket, p2,coef);
     else
     {
       poly _p = (PR->t_p != NULL ? PR->t_p : PR->p);

--- a/kernel/GBEngine/kspoly.cc
+++ b/kernel/GBEngine/kspoly.cc
@@ -162,6 +162,158 @@ int ksReducePoly(LObject* PR,
   return ret;
 }
 
+/* Computes a reduction of the lead coefficient only. We have already tested
+ * that lm(PW) divides lm(PR), but lc(PW) does not divide lc(PR). We have
+ * computed division with remainder on the lead coefficients, parameter
+ * coef is the corresponding multiple for PW we need. The new lead
+ * coefficient, i.e. the remainder of lc division has already been
+ * set before calling this function. We do not drop the lead term at
+ * the end, but keep the adjusted, correct lead term. */
+int ksReducePolyLC(LObject* PR,
+                 TObject* PW,
+                 poly spNoether,
+                 number *coef,
+                 kStrategy strat)
+{
+#ifdef KDEBUG
+  red_count++;
+#ifdef TEST_OPT_DEBUG_RED
+//  if (TEST_OPT_DEBUG)
+//  {
+//    Print("Red %d:", red_count); PR->wrp(); Print(" with:");
+//    PW->wrp();
+//    //printf("\necart(PR)-ecart(PW): %i\n",PR->ecart-PW->ecart);
+//    //pWrite(PR->p);
+//  }
+#endif
+#endif
+  /* printf("PR->P: ");
+   * p_Write(PR->p, currRing, PR->tailRing); */
+  int ret = 0;
+  ring tailRing = PR->tailRing;
+  kTest_L(PR);
+  kTest_T(PW);
+
+  poly p1 = PR->GetLmTailRing();   // p2 | p1
+  poly p2 = PW->GetLmTailRing();   // i.e. will reduce p1 with p2; lm = LT(p1) / LM(p2)
+  poly t2 = pNext(p2), lm = p1;    // t2 = p2 - LT(p2); really compute P = LC(p2)*p1 - LT(p1)/LM(p2)*p2
+  assume(p1 != NULL && p2 != NULL);// Attention, we have rings and there LC(p2) and LC(p1) are special
+  p_CheckPolyRing(p1, tailRing);
+  p_CheckPolyRing(p2, tailRing);
+
+  pAssume1(p2 != NULL && p1 != NULL &&
+           p_DivisibleBy(p2,  p1, tailRing));
+
+  pAssume1(p_GetComp(p1, tailRing) == p_GetComp(p2, tailRing) ||
+           (p_GetComp(p2, tailRing) == 0 &&
+            p_MaxComp(pNext(p2),tailRing) == 0));
+
+#ifdef HAVE_PLURAL
+  if (rIsPluralRing(currRing))
+  {
+    // for the time being: we know currRing==strat->tailRing
+    // no exp-bound checking needed
+    // (only needed if exp-bound(tailring)<exp-b(currRing))
+    if (PR->bucket!=NULL)  nc_kBucketPolyRed(PR->bucket, p2,coef);
+    else
+    {
+      poly _p = (PR->t_p != NULL ? PR->t_p : PR->p);
+      assume(_p != NULL);
+      nc_PolyPolyRed(_p, p2,coef, currRing);
+      if (PR->t_p!=NULL) PR->t_p=_p; else PR->p=_p;
+      PR->pLength=0; // usually not used, GetpLength re-computes it if needed
+    }
+    return 0;
+  }
+#endif
+  /* printf("PR->P2: ");
+   * pWrite(PR->p); */
+
+  /* this part never happens since t2 = p2 and NOT t2 = pNext(p2) */
+  /* if (t2==NULL)           // Divisor is just one term, therefore it will
+   * {                       // just cancel the leading term
+   *   PR->LmDeleteAndIter();
+   *   if (coef != NULL) *coef = n_Init(1, tailRing->cf);
+   *   return 0;
+   * } */
+
+  p_ExpVectorSub(lm, p2, tailRing); // Calculate the Monomial we must multiply to p2
+  p_SetCoeff(lm, n_Init(1, tailRing), tailRing);
+  //if (tailRing != currRing)
+  {
+    // check that reduction does not violate exp bound
+    while (PW->max_exp != NULL && !p_LmExpVectorAddIsOk(lm, PW->max_exp, tailRing))
+    {
+      // undo changes of lm
+      p_ExpVectorAdd(lm, p2, tailRing);
+      if (strat == NULL) return 2;
+      /* if (! kStratChangeTailRing(strat, PR, PW)) return -1; */
+      tailRing = strat->tailRing;
+      p1 = PR->GetLmTailRing();
+      p2 = PW->GetLmTailRing();
+      t2 = pNext(p2);
+      lm = p1;
+      p_ExpVectorSub(lm, p2, tailRing);
+      ret = 1;
+    }
+  }
+
+  // take care of coef buisness
+  // we have done this already in redRingNew
+  /* if (! n_IsOne(pGetCoeff(p2), tailRing->cf))
+   * {
+   *   number bn = pGetCoeff(lm);
+   *   number an = pGetCoeff(p2);
+   *   int ct = ksCheckCoeff(&an, &bn, tailRing->cf);    // Calculate special LC
+   *   p_SetCoeff(lm, bn, tailRing);
+   *   if ((ct == 0) || (ct == 2))
+   *     PR->Tail_Mult_nn(an);
+   *   if (coef != NULL) *coef = an;
+   *   else n_Delete(&an, tailRing->cf);
+   * }
+   * else
+   * {
+   *   if (coef != NULL) *coef = n_Init(1, tailRing->cf);
+   * } */
+
+  // and finally,
+  /* printf("NOW WE REDUCE:\n");
+   * p_Write(lm, tailRing);
+   * p_Write(p2, tailRing); */
+  /* we use p2, since then lm(p2) is the gcd lead monomial and we are done! */
+  PR->Tail_Minus_mm_Mult_qq(lm, p2, pLength(p2) /*PW->GetpLength() - 1*/, spNoether);
+  /* PR->Tail_Minus_mm_Mult_qq(lm, t2, pLength(t2) [>PW->GetpLength() - 1<], spNoether); */
+  assume(PW->GetpLength() == pLength(PW->p != NULL ? PW->p : PW->t_p));
+
+  PR->LmDeleteAndIter();
+  p_SetCoeff(PR->p, *coef, currRing);
+  /* p_SetCoeff(PR->t_p, *coef, tailRing); */
+
+
+  // the following is commented out: shrinking
+#ifdef HAVE_SHIFTBBA_NONEXISTENT
+  if ( (currRing->isLPring) && (!strat->homog) )
+  {
+    // assume? h->p in currRing
+    PR->GetP();
+    poly qq = p_Shrink(PR->p, currRing->isLPring, currRing);
+    PR->Clear(); // does the right things
+    PR->p = qq;
+    PR->t_p = NULL;
+    PR->SetShortExpVector();
+  }
+#endif
+
+#if defined(KDEBUG) && defined(TEST_OPT_DEBUG_RED)
+  if (TEST_OPT_DEBUG)
+  {
+    Print(" to: "); PR->wrp(); Print("\n");
+    //printf("\nt^%i ", PR->ecart);pWrite(pHead(PR->p));
+  }
+#endif
+  return ret;
+}
+
 int ksReducePolyBound(LObject* PR,
                  TObject* PW,
                  int bound,

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -1347,7 +1347,7 @@ void initBba(kStrategy strat)
   }
   if (rField_is_Ring(currRing))
   {
-    if (rField_is_Ring_Z(currRing))
+    if (rField_is_Z(currRing))
       /* strat->red = redRing; */
       strat->red = redRingIntegers;
     else

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -1347,7 +1347,10 @@ void initBba(kStrategy strat)
   }
   if (rField_is_Ring(currRing))
   {
-    strat->red = redRing;
+    if (rField_is_Ring_Z(currRing))
+      strat->red = redRingIntegers;
+    else
+      strat->red = redRing;
   }
   if (currRing->pLexOrder && strat->honey)
     strat->initEcart = initEcartNormal;

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -1348,6 +1348,7 @@ void initBba(kStrategy strat)
   if (rField_is_Ring(currRing))
   {
     if (rField_is_Ring_Z(currRing))
+      /* strat->red = redRing; */
       strat->red = redRingIntegers;
     else
       strat->red = redRing;

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -1349,7 +1349,7 @@ void initBba(kStrategy strat)
   {
     if (rField_is_Z(currRing))
       /* strat->red = redRing; */
-      strat->red = redRingIntegers;
+      strat->red = redRing_Z;
     else
       strat->red = redRing;
   }

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -111,12 +111,15 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
 #if COEF_NEGATION_CHECK
         if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
             n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf))
+            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
+
+          nDelete(&a);
 #else
         if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf))
+            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
 #endif
           return j;
+        }
       }
 #else
       if (!(sevT[j] & not_sev) &&
@@ -125,12 +128,15 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
 #if COEF_NEGATION_CHECK
         if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
             n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf))
+            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
+
+          nDelete(&a);
 #else
         if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf))
+            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
 #endif
           return j;
+        }
       }
 #endif
       j++;
@@ -154,12 +160,14 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
 #if COEF_NEGATION_CHECK
         if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
             n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf))
+            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
+          nDelete(&a);
 #else
         if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf))
+            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
 #endif
           return j;
+        }
       }
 #else
       if (!(sevT[j] & not_sev) &&
@@ -168,12 +176,14 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
 #if COEF_NEGATION_CHECK
         if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
             n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf))
+            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
+          nDelete(&a);
 #else
         if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf))
+            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
 #endif
           return j;
+        }
       }
 #endif
       j++;
@@ -540,6 +550,7 @@ int redRingIntegers (LObject* h,kStrategy strat)
   if (h->IsNull()) return 0; // spoly is zero (can only occure with zero divisors)
   if (strat->tl<0) return 1;
 
+  number mult, rest;
   int at/*,i*/;
   long d;
   int j = 0;
@@ -601,13 +612,13 @@ int redRingIntegers (LObject* h,kStrategy strat)
       tj  = strat->T[j];
       tj.Copy();
       /* compute division with remainder of lc(h) and lc(T[j]) */
-      number a, d;
-      d = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p), &a, currRing->cf);
+      rest = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p),
+          &mult, currRing->cf);
       /* set corresponding new lead coefficient already. we do not
        * remove the lead term in ksReducePolyLC, but only apply
        * a lead coefficient reduction */
-      tj.Mult_nn(d);
-      ksReducePolyLC(h, &tj, NULL, &a, strat);
+      tj.Mult_nn(rest);
+      ksReducePolyLC(h, &tj, NULL, &mult, strat);
       tj.Delete();
     }
     /* printf("\nAfter small red: ");pWrite(h->p); */

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -44,8 +44,6 @@
 #define SBA_PRINT_SIZE_SYZ                  0
 #define SBA_PRINT_PRODUCT_CRITERION         0
 
-#define COEF_NEGATION_CHECK 1
-
 // counts sba's reduction steps
 #if SBA_PRINT_REDUCTION_STEPS
 long sba_reduction_steps;
@@ -91,6 +89,7 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
 
   const TSet T=strat->T;
   const unsigned long* sevT=strat->sevT;
+  number rest, mult;
   if (L->p!=NULL)
   {
     const ring r=currRing;
@@ -98,26 +97,15 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
 
     pAssume(~not_sev == p_GetShortExpVector(p, r));
 
-#if COEF_NEGATION_CHECK
-    number a = n_Copy(pGetCoeff(p), currRing->cf);
-    n_InpNeg(a, currRing->cf);
-#endif
     loop
     {
       if (j > strat->tl) return -1;
 #if defined(PDEBUG) || defined(PDIV_DEBUG)
       if (p_LmShortDivisibleBy(T[j].p, sevT[j],p, not_sev, r))
       {
-#if COEF_NEGATION_CHECK
-        if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
-
-          nDelete(&a);
-#else
-        if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
-#endif
+        mult= n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].p),
+            &rest, currRing->cf);
+        if (!n_IsZero(mult, currRing)) {
           return j;
         }
       }
@@ -125,16 +113,9 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
       if (!(sevT[j] & not_sev) &&
           p_LmDivisibleBy(T[j].p, p, r))
       {
-#if COEF_NEGATION_CHECK
-        if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
-
-          nDelete(&a);
-#else
-        if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
-#endif
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].p),
+            &rest, currRing->cf);
+        if (!n_IsZero(mult, currRing)) {
           return j;
         }
       }
@@ -146,10 +127,6 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
   {
     const poly p=L->t_p;
     const ring r=strat->tailRing;
-#if COEF_NEGATION_CHECK
-    number a = n_Copy(pGetCoeff(p), currRing->cf);
-    n_InpNeg(a, currRing->cf);
-#endif
     loop
     {
       if (j > strat->tl) return -1;
@@ -157,15 +134,9 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
       if (p_LmShortDivisibleBy(T[j].t_p, sevT[j],
             p, not_sev, r))
       {
-#if COEF_NEGATION_CHECK
-        if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
-          nDelete(&a);
-#else
-        if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
-#endif
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].p),
+            &rest, currRing->cf);
+        if (!n_IsZero(mult, currRing)) {
           return j;
         }
       }
@@ -173,15 +144,9 @@ int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const i
       if (!(sevT[j] & not_sev) &&
           p_LmDivisibleBy(T[j].t_p, p, r))
       {
-#if COEF_NEGATION_CHECK
-        if( n_DivBy(a, pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(a, pGetCoeff(T[j].p), r->cf)) {
-          nDelete(&a);
-#else
-        if( n_DivBy(pGetCoeff(p), pGetCoeff(T[j].p), r->cf) ||
-            n_Greater(pGetCoeff(p), pGetCoeff(T[j].p), r->cf)) {
-#endif
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].p),
+            &rest, currRing->cf);
+        if (!n_IsZero(mult, currRing)) {
           return j;
         }
       }

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -569,57 +569,55 @@ int redRingIntegers (LObject* h,kStrategy strat)
     /* we do not check divisibility of lead coefficients over rings.
      * this is postponed and checked directly before deciding how to reduce h */
     j = kFindDivisibleByInT(strat, h);
-    if (j < 0)
+    if (j < 0) {
       j = kFindDivisibleByInTIntegers(strat, h);
-    if (j < 0)
-    {
-      // over ZZ: cleanup coefficients by complete reduction with monomials
-      postReduceByMon(h, strat);
-      if(h->p == NULL)
+      if (j < 0)
       {
-        if (h->lcm!=NULL) pLmDelete(h->lcm);
-        h->Clear();
-        tj.Clear();
-        return 0;
-      }
-      if(nIsZero(pGetCoeff(h->p))) return 2;
-      j = kFindDivisibleByInT(strat, h);
-      if(j < 0)
-      {
-        if(strat->tl >= 0)
-            h->i_r1 = strat->tl;
-        else
-            h->i_r1 = -1;
-        if (h->GetLmTailRing() == NULL)
+        // over ZZ: cleanup coefficients by complete reduction with monomials
+        postReduceByMon(h, strat);
+        if(h->p == NULL)
         {
           if (h->lcm!=NULL) pLmDelete(h->lcm);
           h->Clear();
           tj.Clear();
           return 0;
         }
-        return 1;
-      }
-    }
-    if(n_DivBy(pGetCoeff(h->p), pGetCoeff(strat->T[j].p), currRing->cf)) {
-      ksReducePoly(h, &(strat->T[j]), NULL, NULL, strat);
-    } else {
-      /* add h to T: it may be useful as a better reducer */
-      /* enterT(*h, strat); */
-      /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
-       * => gcd-poly reduction */
+        if(nIsZero(pGetCoeff(h->p))) return 2;
+        j = kFindDivisibleByInT(strat, h);
+        if(j < 0)
+        {
+          if(strat->tl >= 0)
+              h->i_r1 = strat->tl;
+          else
+              h->i_r1 = -1;
+          if (h->GetLmTailRing() == NULL)
+          {
+            if (h->lcm!=NULL) pLmDelete(h->lcm);
+            h->Clear();
+            tj.Clear();
+            return 0;
+          }
+          return 1;
+        }
+      } else {
+        /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
+        * => gcd-poly reduction */
 
-      /* first copy T[j] in order to multiply it with a coefficient later on */
-      tj  = strat->T[j];
-      tj.Copy();
-      /* compute division with remainder of lc(h) and lc(T[j]) */
-      rest = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p),
-          &mult, currRing->cf);
-      /* set corresponding new lead coefficient already. we do not
-       * remove the lead term in ksReducePolyLC, but only apply
-       * a lead coefficient reduction */
-      tj.Mult_nn(rest);
-      ksReducePolyLC(h, &tj, NULL, &mult, strat);
-      tj.Delete();
+        /* first copy T[j] in order to multiply it with a coefficient later on */
+        tj  = strat->T[j];
+        tj.Copy();
+        /* compute division with remainder of lc(h) and lc(T[j]) */
+        rest = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p),
+            &mult, currRing->cf);
+        /* set corresponding new lead coefficient already. we do not
+        * remove the lead term in ksReducePolyLC, but only apply
+        * a lead coefficient reduction */
+        tj.Mult_nn(rest);
+        ksReducePolyLC(h, &tj, NULL, &mult, strat);
+        tj.Delete();
+      }
+    } else {
+      ksReducePoly(h, &(strat->T[j]), NULL, NULL, strat);
     }
     /* printf("\nAfter small red: ");pWrite(h->p); */
     if (h->GetLmTailRing() == NULL)

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -2341,6 +2341,11 @@ ideal bba (ideal F, ideal Q,intvec *w,intvec *hilb,kStrategy strat)
         minimcnt++;
       }
 
+      // a first test for removing old pairs where
+      // strat->P.p divides lcm of pair
+      /* if (rField_is_Ring(currRing))
+       *   pairLcmCriterion(strat); */
+
       // enter into S, L, and T
       if ((!TEST_OPT_IDLIFT) || (pGetComp(strat->P.p) <= strat->syzComp))
       {

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -510,7 +510,7 @@ poly kFindZeroPoly(poly input_p, ring leadRing, ring tailRing)
 /*2
 *  reduction procedure for the ring Z/2^m
 */
-int redRingIntegers (LObject* h,kStrategy strat)
+int redRing_Z (LObject* h,kStrategy strat)
 {
   if (h->IsNull()) return 0; // spoly is zero (can only occure with zero divisors)
   if (strat->tl<0) return 1;

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -2343,8 +2343,8 @@ ideal bba (ideal F, ideal Q,intvec *w,intvec *hilb,kStrategy strat)
 
       // a first test for removing old pairs where
       // strat->P.p divides lcm of pair
-      /* if (rField_is_Ring(currRing))
-       *   pairLcmCriterion(strat); */
+      if (rField_is_Ring(currRing))
+        pairLcmCriterion(strat);
 
       // enter into S, L, and T
       if ((!TEST_OPT_IDLIFT) || (pGetComp(strat->P.p) <= strat->syzComp))

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -82,7 +82,7 @@ long sba_interreduction_operations;
 
 // return -1 if no divisor is found
 //        number of first divisor, otherwise
-int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const int start)
+int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int start)
 {
   unsigned long not_sev = ~L->sev;
   int j = start;
@@ -535,7 +535,7 @@ int redRing_Z (LObject* h,kStrategy strat)
      * this is postponed and checked directly before deciding how to reduce h */
     j = kFindDivisibleByInT(strat, h);
     if (j < 0) {
-      j = kFindDivisibleByInTIntegers(strat, h);
+      j = kFindDivisibleByInT_Z(strat, h);
       if (j < 0)
       {
         // over ZZ: cleanup coefficients by complete reduction with monomials

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -1333,7 +1333,7 @@ static void enterOnePairRing (int i,poly p,int /*ecart*/, int isFromQ,kStrategy 
   }
   h.lcm = p_Lcm(p,strat->S[i],currRing);
   pSetCoeff0(h.lcm, n_Lcm(pGetCoeff(p), pGetCoeff(strat->S[i]), currRing->cf));
-  if(nIsZero(pGetCoeff(h.lcm)))
+  if (nIsZero(pGetCoeff(h.lcm)))
   {
       strat->cp++;
       pLmDelete(h.lcm);

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -3924,7 +3924,6 @@ void pairLcmCriterion(kStrategy strat)
 				/* !(strat->sevS[j] & ~sev) && */
 				p_LmDivisibleBy(strat->L[l].p, t, currRing)) {
 			deleteInL(strat->L, &strat->Ll, l, strat);
-			printf("!!\n");
 		}
 	}
 }

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -1526,19 +1526,21 @@ static BOOLEAN enterOneStrongPoly (int i,poly p,int /*ecart*/, int /*isFromQ*/,k
 
   k_GetStrongLeadTerms(p, si, currRing, m1, m2, gcd, strat->tailRing);
 
-  unsigned long sev = pGetShortExpVector(gcd);
+  if (!rHasMixedOrdering(currRing)) {
+    unsigned long sev = pGetShortExpVector(gcd);
 
-  for (int j = 0; j < strat->sl; j++) {
-    if (j == i)
-      continue;
+    for (int j = 0; j < strat->sl; j++) {
+      if (j == i)
+        continue;
 
-    if (n_DivBy(d, pGetCoeff(strat->S[j]), currRing->cf) &&
-        !(strat->sevS[j] & ~sev) &&
-        p_LmDivisibleBy(strat->S[j], gcd, currRing)) {
-      nDelete(&d);
-      nDelete(&s);
-      nDelete(&t);
-      return FALSE;
+      if (n_DivBy(d, pGetCoeff(strat->S[j]), currRing->cf) &&
+          !(strat->sevS[j] & ~sev) &&
+          p_LmDivisibleBy(strat->S[j], gcd, currRing)) {
+        nDelete(&d);
+        nDelete(&s);
+        nDelete(&t);
+        return FALSE;
+      }
     }
   }
 
@@ -1600,7 +1602,7 @@ static BOOLEAN enterOneStrongPoly (int i,poly p,int /*ecart*/, int /*isFromQ*/,k
   int posx;
   h.pCleardenom();
   strat->initEcart(&h);
-  h.sev = sev;
+  h.sev = pGetShortExpVector(h.p);
   h.i_r1 = -1;h.i_r2 = -1;
   if (currRing!=strat->tailRing)
     h.t_p = k_LmInit_currRing_2_tailRing(h.p, strat->tailRing);

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -3912,8 +3912,23 @@ void initenterpairsSigRing (poly h,poly hSig,int hFrom,int k,int ecart,int isFro
 #endif
   }
 }
-
 #ifdef HAVE_RINGS
+// a first test for removing old pairs where
+// strat->P.p divides lcm of pair
+void pairLcmCriterion(kStrategy strat)
+{
+	number a  = pGetCoeff(strat->P.p);
+	poly t    = strat->P.p;
+	for (int l = 0; l < strat->Ll; ++l) {
+		if (n_DivBy(a, pGetCoeff(strat->L[l].p), currRing->cf) &&
+				/* !(strat->sevS[j] & ~sev) && */
+				p_LmDivisibleBy(strat->L[l].p, t, currRing)) {
+			deleteInL(strat->L, &strat->Ll, l, strat);
+			printf("!!\n");
+		}
+	}
+}
+
 /*2
 *the pairset B of pairs of type (s[i],p) is complete now. It will be updated
 *using the chain-criterion in B and L and enters B to L

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -1520,6 +1520,23 @@ static BOOLEAN enterOneStrongPoly (int i,poly p,int /*ecart*/, int /*isFromQ*/,k
   }
 
   k_GetStrongLeadTerms(p, si, currRing, m1, m2, gcd, strat->tailRing);
+
+  unsigned long sev = pGetShortExpVector(gcd);
+
+  for (int j = 0; j < strat->sl; j++) {
+    if (j == i)
+      continue;
+
+    if (n_DivBy(d, pGetCoeff(strat->S[j]), currRing->cf) &&
+        !(strat->sevS[j] & ~sev) &&
+        p_LmDivisibleBy(strat->S[j], gcd, currRing)) {
+      nDelete(&d);
+      nDelete(&s);
+      nDelete(&t);
+      return FALSE;
+    }
+  }
+
   //p_Test(m1,strat->tailRing);
   //p_Test(m2,strat->tailRing);
   /*if(!enterTstrong)
@@ -1578,7 +1595,7 @@ static BOOLEAN enterOneStrongPoly (int i,poly p,int /*ecart*/, int /*isFromQ*/,k
   int posx;
   h.pCleardenom();
   strat->initEcart(&h);
-  h.sev = pGetShortExpVector(h.p);
+  h.sev = sev;
   h.i_r1 = -1;h.i_r2 = -1;
   if (currRing!=strat->tailRing)
     h.t_p = k_LmInit_currRing_2_tailRing(h.p, strat->tailRing);

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -1326,9 +1326,14 @@ static void enterOnePairRing (int i,poly p,int /*ecart*/, int isFromQ,kStrategy 
   h.ecart=0; h.length=0;
 #endif
   /*- computes the lcm(s[i],p) -*/
+  if(pHasNotCF(p,strat->S[i]))
+  {
+      strat->cp++;
+      return;
+  }
   h.lcm = p_Lcm(p,strat->S[i],currRing);
   pSetCoeff0(h.lcm, n_Lcm(pGetCoeff(p), pGetCoeff(strat->S[i]), currRing->cf));
-  if (nIsZero(pGetCoeff(h.lcm)))
+  if(nIsZero(pGetCoeff(h.lcm)))
   {
       strat->cp++;
       pLmDelete(h.lcm);
@@ -3921,7 +3926,6 @@ void pairLcmCriterion(kStrategy strat)
 	poly t    = strat->P.p;
 	for (int l = 0; l < strat->Ll; ++l) {
 		if (n_DivBy(a, pGetCoeff(strat->L[l].p), currRing->cf) &&
-				/* !(strat->sevS[j] & ~sev) && */
 				p_LmDivisibleBy(strat->L[l].p, t, currRing)) {
 			deleteInL(strat->L, &strat->Ll, l, strat);
 		}

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -504,7 +504,7 @@ poly redNFTail (poly h,const int sl,kStrategy strat);
 int redHoney (LObject* h, kStrategy strat);
 #ifdef HAVE_RINGS
 int redRing (LObject* h,kStrategy strat);
-int redRingIntegers (LObject* h,kStrategy strat);
+int redRing_Z (LObject* h,kStrategy strat);
 int redRiloc (LObject* h,kStrategy strat);
 void enterExtendedSpoly(poly h,kStrategy strat);
 void enterExtendedSpolySig(poly h,poly hSig,kStrategy strat);

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -593,7 +593,7 @@ int kFindInT(poly p, TSet T, int tlength);
 /// return -1 if no divisor is found
 ///        number of first divisor in T, otherwise
 int kFindDivisibleByInT(const kStrategy strat, const LObject* L, const int start=0);
-int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const int start=0);
+int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int start=0);
 
 /// return -1 if no divisor is found
 ///        number of first divisor in S, otherwise

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -504,6 +504,7 @@ poly redNFTail (poly h,const int sl,kStrategy strat);
 int redHoney (LObject* h, kStrategy strat);
 #ifdef HAVE_RINGS
 int redRing (LObject* h,kStrategy strat);
+int redRingIntegers (LObject* h,kStrategy strat);
 int redRiloc (LObject* h,kStrategy strat);
 void enterExtendedSpoly(poly h,kStrategy strat);
 void enterExtendedSpolySig(poly h,poly hSig,kStrategy strat);
@@ -591,6 +592,7 @@ int kFindInT(poly p, TSet T, int tlength);
 /// return -1 if no divisor is found
 ///        number of first divisor in T, otherwise
 int kFindDivisibleByInT(const kStrategy strat, const LObject* L, const int start=0);
+int kFindDivisibleByInTIntegers(const kStrategy strat, const LObject* L, const int start=0);
 
 /// return -1 if no divisor is found
 ///        number of first divisor in S, otherwise
@@ -687,6 +689,12 @@ void f5c (kStrategy strat, int& olddeg, int& minimcnt, int& hilbeledeg,
 //         -1 tailRing change could not be performed due to exceeding exp
 //            bound of currRing
 int ksReducePoly(LObject* PR,
+                 TObject* PW,
+                 poly spNoether = NULL,
+                 number *coef = NULL,
+                 kStrategy strat = NULL);
+
+int ksReducePolyLC(LObject* PR,
                  TObject* PW,
                  poly spNoether = NULL,
                  number *coef = NULL,

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -573,6 +573,7 @@ void updateResult(ideal r,ideal Q,kStrategy strat);
 void completeReduce (kStrategy strat, BOOLEAN withT=FALSE);
 void kFreeStrat(kStrategy strat);
 void enterOnePairNormal (int i,poly p,int ecart, int isFromQ,kStrategy strat, int atR);
+void pairLcmCriterion(kStrategy strat);
 void chainCritNormal (poly p,int ecart,kStrategy strat);
 void chainCritOpt_1 (poly,int,kStrategy strat);
 void chainCritSig (poly p,int ecart,kStrategy strat);


### PR DESCRIPTION
1. Improves criteria checks for normal S-pairs and GCD-pairs
2. Introduces a new reduction function especially for Z: Allows reductions of lead coefficients if the lead monomial cannot be cancelled out, thus we get less overhead in the intermediate basis and the pair set.