### PR TITLE
fixes example primdecZM from primdecint.lib

### DIFF
--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -1348,7 +1348,6 @@ void initBba(kStrategy strat)
   if (rField_is_Ring(currRing))
   {
     if (rField_is_Z(currRing))
-      /* strat->red = redRing; */
       strat->red = redRing_Z;
     else
       strat->red = redRing;

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -2306,11 +2306,6 @@ ideal bba (ideal F, ideal Q,intvec *w,intvec *hilb,kStrategy strat)
         minimcnt++;
       }
 
-      // a first test for removing old pairs where
-      // strat->P.p divides lcm of pair
-      if (rField_is_Ring(currRing))
-        pairLcmCriterion(strat);
-
       // enter into S, L, and T
       if ((!TEST_OPT_IDLIFT) || (pGetComp(strat->P.p) <= strat->syzComp))
       {

--- a/kernel/GBEngine/kutil.cc
+++ b/kernel/GBEngine/kutil.cc
@@ -3929,20 +3929,6 @@ void initenterpairsSigRing (poly h,poly hSig,int hFrom,int k,int ecart,int isFro
   }
 }
 #ifdef HAVE_RINGS
-// a first test for removing old pairs where
-// strat->P.p divides lcm of pair
-void pairLcmCriterion(kStrategy strat)
-{
-	number a  = pGetCoeff(strat->P.p);
-	poly t    = strat->P.p;
-	for (int l = 0; l < strat->Ll; ++l) {
-		if (n_DivBy(a, pGetCoeff(strat->L[l].p), currRing->cf) &&
-				p_LmDivisibleBy(strat->L[l].p, t, currRing)) {
-			deleteInL(strat->L, &strat->Ll, l, strat);
-		}
-	}
-}
-
 /*2
 *the pairset B of pairs of type (s[i],p) is complete now. It will be updated
 *using the chain-criterion in B and L and enters B to L

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -573,7 +573,6 @@ void updateResult(ideal r,ideal Q,kStrategy strat);
 void completeReduce (kStrategy strat, BOOLEAN withT=FALSE);
 void kFreeStrat(kStrategy strat);
 void enterOnePairNormal (int i,poly p,int ecart, int isFromQ,kStrategy strat, int atR);
-void pairLcmCriterion(kStrategy strat);
 void chainCritNormal (poly p,int ecart,kStrategy strat);
 void chainCritOpt_1 (poly,int,kStrategy strat);
 void chainCritSig (poly p,int ecart,kStrategy strat);


### PR DESCRIPTION
The problem was a criterion which cannot be used in the module case. Since we found out that the criterion is, for the ideal case, already included in the Gebauer-Möller installation of std, we can remove the criterion completely.