### PR TITLE
Pretty printing for LP

### DIFF
--- a/Tst/Manual/lpMonomialPrinting.res.gz.uu
+++ b/Tst/Manual/lpMonomialPrinting.res.gz.uu
@@ -1,0 +1,10 @@
+begin 644 lpMonomialPrinting.res.gz
+M'XL(",\R`5P"`VQP36]N;VUI86Q0<FEN=&EN9RYR97,`=9'!3L,P#(;O?0IK
+MXM!65;<"`Z:*'!"720.AC7N5=ED5T:55XD';I\=)2^#"R<YG_W^<^/#^O'T%
+M@(S!;OL$"S28-K)<Y$!9(97$,,H#&X$Q:+J75K5GR9LW+15*5:=*?*4&.0:'
+MV>EZ=CII(>IR,O/%&P8DK$'#(ZR2L$^&9(R28_?;<<O@*$ZPIX8S_Q`[@2AT
+MU_!*[$D8KJ,<EDNH6F507RHTP.%/CW/W7FL&1J"[<.]D=#)0<B,<P_9_Z1V#
+M3Z[#C![?>W@_09HA*.+!XX<);QPNXM$7-@SZN(]'\K#AAV<K!D,\$.KS8$Y\
+>C18Q.C1:G4]]G;[7;L9^^<78^:Z";\#/O7;$`0``
+`
+end

--- a/Tst/Manual/lpMonomialPrinting.stat
+++ b/Tst/Manual/lpMonomialPrinting.stat
@@ -1,0 +1,4 @@
+1 >> tst_memory_0 :: 1543582415:4113, 64 bit:4.1.1:x86_64-Darwin:133-128.eduroam.rwth-aachen.de:681544
+1 >> tst_memory_1 :: 1543582415:4113, 64 bit:4.1.1:x86_64-Darwin:133-128.eduroam.rwth-aachen.de:2097168
+1 >> tst_memory_2 :: 1543582415:4113, 64 bit:4.1.1:x86_64-Darwin:133-128.eduroam.rwth-aachen.de:2121872
+1 >> tst_timer_1 :: 1543582415:4113, 64 bit:4.1.1:x86_64-Darwin:133-128.eduroam.rwth-aachen.de:72

--- a/Tst/Manual/lpMonomialPrinting.tst
+++ b/Tst/Manual/lpMonomialPrinting.tst
@@ -1,0 +1,12 @@
+LIB "tst.lib"; tst_init();
+LIB "freegb.lib";
+ring r = 0,(x,y,z),dp;
+def R = makeLetterplaceRing(5); // constructs a Letterplace ring
+setring R; // sets basering to Letterplace ring
+var(1);
+var(5);
+var(9);
+x*x*z;
+y*y*x*x;
+z*y*x*z*z;
+tst_status(1);$


### PR DESCRIPTION
Better priniting of invalid letterplace monomials

examples:
`x(2)*y(4) = _*x*_*y`
`x(2)*x(3)*y(3)*x(5) = _*x*x&y*_*x`

nothing changes if the monomial is valid:
`x(1)*y(2)*x(3) = x*y*x`