### PR TITLE
correct spelling errors as detected by lintian

### DIFF
--- a/kernel/linear_algebra/linearAlgebra.cc
+++ b/kernel/linear_algebra/linearAlgebra.cc
@@ -968,7 +968,7 @@ void hessenberg(const matrix aMat, matrix &pMat, matrix &hessenbergMat,
 
 /**
  * Performs one transformation step on the given matrix H as part of
- * the gouverning QR double shift algorith.
+ * the gouverning QR double shift algorithm.
  * The method will change the given matrix H side-effect-wise. The resulting
  * matrix H' will be in Hessenberg form.
  * The iteration index is needed, since for the 11th and 21st iteration,

--- a/libpolys/polys/matpol.cc
+++ b/libpolys/polys/matpol.cc
@@ -2159,7 +2159,7 @@ poly mp_Det(matrix a, const ring r, DetVariant d/*=DetDefault*/)
       return p;
     }
     default:
-      WerrorS("unknown algorith for det");
+      WerrorS("unknown algorithm for det");
   }
 }
 


### PR DESCRIPTION
Description: source typo
 Correct spelling errors as reported by lintian in the binary library; meant
 to silence lintian and eventually to be submitted to the upstream maintainer.
Origin: vendor, Debian
Comment: spelling-error-in-binary
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2019-01-12