### PR TITLE
Optimizations for local reductions over the integers

### DIFF
--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -536,7 +536,7 @@ int redRiloc_Z (LObject* h,kStrategy strat)
          * T[0] is 0 (constant). This is only efficient if T[0] is short, thus
          * we ask for the length of T[0] to be <= 2 */
         if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
-            j = kFindDivisibleByInT_Z_only_first(strat, h);
+            j = kTestDivisibleByT0_Z(strat, h);
             if (j == 0 && n_DivBy(pGetCoeff(h->p), pGetCoeff(strat->T[j].p), currRing->cf) == FALSE) {
                 if (strat->T[j].ecart <= h->ecart) {
                     /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
@@ -985,7 +985,7 @@ static poly redMoraNFRing (poly h,kStrategy strat, int flag)
          * T[0] is 0 (constant). This is only efficient if T[0] is short, thus
          * we ask for the length of T[0] to be <= 2 */
         if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
-            j0 = kFindDivisibleByInT_Z_only_first(strat, &H);
+            j0 = kTestDivisibleByT0_Z(strat, &H);
             if (j0 == 0 && n_DivBy(pGetCoeff(H.p), pGetCoeff(strat->T[j0].p), currRing->cf) == FALSE) {
                 if (strat->T[j0].ecart <= H.ecart) {
                     /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -530,7 +530,6 @@ int redRiloc_Z (LObject* h,kStrategy strat)
     d = h->GetpFDeg()+ h->ecart;
     reddeg = strat->LazyDegree+d;
     h->SetShortExpVector();
-    /* printf("new reduction\n"); */
     loop
     {
         /* cut down the lead coefficients, only possible if the degree of
@@ -538,21 +537,14 @@ int redRiloc_Z (LObject* h,kStrategy strat)
          * we ask for the length of T[0] to be <= 2 */
         if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
             j = kFindDivisibleByInT_Z_only_first(strat, h);
-            /* printf("j %d --> ", j);
-             * pWrite(pHead(strat->T[j].p)); */
             if (j == 0 && n_DivBy(pGetCoeff(h->p), pGetCoeff(strat->T[j].p), currRing->cf) == FALSE) {
-                /* printf("ecart h %d < %d ?\n",h->ecart, strat->T[j].ecart); */
                 if (strat->T[j].ecart <= h->ecart) {
-                    /* printf("ja\n");
-                     * printf("before: ");
-                     * pWrite(pHead(h->p)); */
                     /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
                      * => we try to cut down the lead coefficient at least */
                     /* first copy T[j] in order to multiply it with a coefficient later on */
                     number mult, rest;
                     TObject tj  = strat->T[j];
                     tj.Copy();
-                    /* tj.max_exp = strat->T[j].max_exp; */
                     /* compute division with remainder of lc(h) and lc(T[j]) */
                     mult = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p),
                             &rest, currRing->cf);
@@ -563,40 +555,12 @@ int redRiloc_Z (LObject* h,kStrategy strat)
                     ksReducePolyLC(h, &tj, NULL, &rest, strat);
                     tj.Delete();
                     tj.Clear();
-                    /* printf("after: ");
-                     * pWrite(pHead(h->p)); */
                 }
             }
         }
-        /* pWrite(pHead(h->p)); */
         j = kFindDivisibleByInT(strat, h);
         if (j < 0)
         {
-            /* printf("h goes out as: ");
-             * pWrite(pHead(h->p)); */
-#if 0
-            if (j >= 0)
-            {
-                printf("ja\n");
-                /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
-                 * => we try to cut down the lead coefficient at least */
-                /* first copy T[j] in order to multiply it with a coefficient later on */
-                number mult, rest;
-                TObject tj  = strat->T[j];
-                tj.Copy();
-                /* tj.max_exp = strat->T[j].max_exp; */
-                /* compute division with remainder of lc(h) and lc(T[j]) */
-                mult = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p),
-                        &rest, currRing->cf);
-                /* set corresponding new lead coefficient already. we do not
-                 * remove the lead term in ksReducePolyLC, but only apply
-                 * a lead coefficient reduction */
-                tj.Mult_nn(mult);
-                ksReducePolyLC(h, &tj, NULL, &rest, strat);
-                tj.Delete();
-                tj.Clear();
-            }
-#endif
             // over ZZ: cleanup coefficients by complete reduction with monomials
             postReduceByMon(h, strat);
             if(h->p == NULL)
@@ -1006,40 +970,33 @@ static poly redMoraNF (poly h,kStrategy strat, int flag)
 #ifdef HAVE_RINGS
 static poly redMoraNFRing (poly h,kStrategy strat, int flag)
 {
-  LObject H;
-  H.p = h;
-  int j = 0;
-  int z = 10;
-  int o = H.SetpFDeg();
-  H.ecart = currRing->pLDeg(H.p,&H.length,currRing)-o;
-  if ((flag & 2) == 0) cancelunit(&H,TRUE);
-  H.sev = pGetShortExpVector(H.p);
-  unsigned long not_sev = ~ H.sev;
-  loop
-  {
-#if 0
+    LObject H;
+    H.p = h;
+    int j0, j = 0;
+    int z = 10;
+    int o = H.SetpFDeg();
+    H.ecart = currRing->pLDeg(H.p,&H.length,currRing)-o;
+    if ((flag & 2) == 0) cancelunit(&H,TRUE);
+    H.sev = pGetShortExpVector(H.p);
+    unsigned long not_sev = ~ H.sev;
+    loop
+    {
+#if 1
         /* cut down the lead coefficients, only possible if the degree of
          * T[0] is 0 (constant). This is only efficient if T[0] is short, thus
          * we ask for the length of T[0] to be <= 2 */
         if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
-            j = kFindDivisibleByInT_Z_only_first(strat, &H);
-            /* printf("j %d --> ", j);
-             * pWrite(pHead(strat->T[j].p)); */
-            if (j == 0 && n_DivBy(pGetCoeff(H.p), pGetCoeff(strat->T[j].p), currRing->cf) == FALSE) {
-                /* printf("ecart h %d < %d ?\n",h->ecart, strat->T[j].ecart); */
-                if (strat->T[j].ecart <= H.ecart) {
-                    /* printf("ja\n");
-                     * printf("before: ");
-                     * pWrite(pHead(h->p)); */
+            j0 = kFindDivisibleByInT_Z_only_first(strat, &H);
+            if (j0 == 0 && n_DivBy(pGetCoeff(H.p), pGetCoeff(strat->T[j0].p), currRing->cf) == FALSE) {
+                if (strat->T[j0].ecart <= H.ecart) {
                     /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
                      * => we try to cut down the lead coefficient at least */
-                    /* first copy T[j] in order to multiply it with a coefficient later on */
+                    /* first copy T[j0] in order to multiply it with a coefficient later on */
                     number mult, rest;
-                    TObject tj  = strat->T[j];
+                    TObject tj  = strat->T[j0];
                     tj.Copy();
-                    /* tj.max_exp = strat->T[j].max_exp; */
                     /* compute division with remainder of lc(h) and lc(T[j]) */
-                    mult = n_QuotRem(pGetCoeff(H.p), pGetCoeff(strat->T[j].p),
+                    mult = n_QuotRem(pGetCoeff(H.p), pGetCoeff(strat->T[j0].p),
                             &rest, currRing->cf);
                     /* set corresponding new lead coefficient already. we do not
                      * remove the lead term in ksReducePolyLC, but only apply
@@ -1048,99 +1005,96 @@ static poly redMoraNFRing (poly h,kStrategy strat, int flag)
                     ksReducePolyLC(&H, &tj, NULL, &rest, strat);
                     tj.Delete();
                     tj.Clear();
-                    /* printf("after: ");
-                     * pWrite(pHead(h->p)); */
                 }
             }
         }
-    j = 0;
 #endif
-    if (j > strat->tl)
-    {
-      return H.p;
-    }
-    if (TEST_V_DEG_STOP)
-    {
-      if (kModDeg(H.p)>Kstd1_deg) pLmDelete(&H.p);
-      if (H.p==NULL) return NULL;
-    }
-    if (p_LmShortDivisibleBy(strat->T[j].GetLmTailRing(), strat->sevT[j], H.GetLmTailRing(), not_sev, strat->tailRing)
-        && (n_DivBy(H.p->coef, strat->T[j].p->coef,strat->tailRing->cf))
-        )
-    {
-      /*- remember the found T-poly -*/
-      // poly pi = strat->T[j].p;
-      int ei = strat->T[j].ecart;
-      int li = strat->T[j].length;
-      int ii = j;
-      /*
-      * the polynomial to reduce with (up to the moment) is;
-      * pi with ecart ei and length li
-      */
-      loop
-      {
-        /*- look for a better one with respect to ecart -*/
-        /*- stop, if the ecart is small enough (<=ecart(H)) -*/
-        j++;
-        if (j > strat->tl) break;
-        if (ei <= H.ecart) break;
-        if (((strat->T[j].ecart < ei)
-          || ((strat->T[j].ecart == ei)
-        && (strat->T[j].length < li)))
-        && pLmShortDivisibleBy(strat->T[j].p,strat->sevT[j], H.p, not_sev)
-        && (n_DivBy(H.p->coef, strat->T[j].p->coef,strat->tailRing->cf))
-        )
+        if (j > strat->tl)
         {
-          /*
-          * the polynomial to reduce with is now;
-          */
-          // pi = strat->T[j].p;
-          ei = strat->T[j].ecart;
-          li = strat->T[j].length;
-          ii = j;
+            return H.p;
         }
-      }
-      /*
-      * end of search: have to reduce with pi
-      */
-      z++;
-      if (z>10)
-      {
-        pNormalize(H.p);
-        z=0;
-      }
-      if ((ei > H.ecart) && (!strat->kHEdgeFound))
-      {
-        /*
-        * It is not possible to reduce h with smaller ecart;
-        * we have to reduce with bad ecart: H has to enter in T
-        */
-        doRed(&H,&(strat->T[ii]),TRUE,strat,TRUE);
-        if (H.p == NULL)
-          return NULL;
-      }
-      else
-      {
-        /*
-        * we reduce with good ecart, h need not to be put to T
-        */
-        doRed(&H,&(strat->T[ii]),FALSE,strat,TRUE);
-        if (H.p == NULL)
-          return NULL;
-      }
-      /*- try to reduce the s-polynomial -*/
-      o = H.SetpFDeg();
-      if ((flag &2 ) == 0) cancelunit(&H,TRUE);
-      H.ecart = currRing->pLDeg(H.p,&(H.length),currRing)-o;
-      j = 0;
-      H.sev = pGetShortExpVector(H.p);
-      not_sev = ~ H.sev;
+        if (TEST_V_DEG_STOP)
+        {
+            if (kModDeg(H.p)>Kstd1_deg) pLmDelete(&H.p);
+            if (H.p==NULL) return NULL;
+        }
+        if (p_LmShortDivisibleBy(strat->T[j].GetLmTailRing(), strat->sevT[j], H.GetLmTailRing(), not_sev, strat->tailRing)
+                && (n_DivBy(H.p->coef, strat->T[j].p->coef,strat->tailRing->cf))
+           )
+        {
+            /*- remember the found T-poly -*/
+            // poly pi = strat->T[j].p;
+            int ei = strat->T[j].ecart;
+            int li = strat->T[j].length;
+            int ii = j;
+            /*
+             * the polynomial to reduce with (up to the moment) is;
+             * pi with ecart ei and length li
+             */
+            loop
+            {
+                /*- look for a better one with respect to ecart -*/
+                /*- stop, if the ecart is small enough (<=ecart(H)) -*/
+                j++;
+                if (j > strat->tl) break;
+                if (ei <= H.ecart) break;
+                if (((strat->T[j].ecart < ei)
+                            || ((strat->T[j].ecart == ei)
+                                && (strat->T[j].length < li)))
+                        && pLmShortDivisibleBy(strat->T[j].p,strat->sevT[j], H.p, not_sev)
+                        && (n_DivBy(H.p->coef, strat->T[j].p->coef,strat->tailRing->cf))
+                   )
+                {
+                    /*
+                     * the polynomial to reduce with is now;
+                     */
+                    // pi = strat->T[j].p;
+                    ei = strat->T[j].ecart;
+                    li = strat->T[j].length;
+                    ii = j;
+                }
+            }
+            /*
+             * end of search: have to reduce with pi
+             */
+            z++;
+            if (z>10)
+            {
+                pNormalize(H.p);
+                z=0;
+            }
+            if ((ei > H.ecart) && (!strat->kHEdgeFound))
+            {
+                /*
+                 * It is not possible to reduce h with smaller ecart;
+                 * we have to reduce with bad ecart: H has to enter in T
+                 */
+                doRed(&H,&(strat->T[ii]),TRUE,strat,TRUE);
+                if (H.p == NULL)
+                    return NULL;
+            }
+            else
+            {
+                /*
+                 * we reduce with good ecart, h need not to be put to T
+                 */
+                doRed(&H,&(strat->T[ii]),FALSE,strat,TRUE);
+                if (H.p == NULL)
+                    return NULL;
+            }
+            /*- try to reduce the s-polynomial -*/
+            o = H.SetpFDeg();
+            if ((flag &2 ) == 0) cancelunit(&H,TRUE);
+            H.ecart = currRing->pLDeg(H.p,&(H.length),currRing)-o;
+            j = 0;
+            H.sev = pGetShortExpVector(H.p);
+            not_sev = ~ H.sev;
+        }
+        else
+        {
+            j++;
+        }
     }
-    else
-    {
-      j++;
-    }
-  }
 }
 #endif
 

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -526,36 +526,42 @@ int redRiloc_Z (LObject* h,kStrategy strat)
     int j = 0;
     int pass = 0;
     long d,reddeg;
+    int docoeffred  = 0;
+    poly T0p        = strat->T[0].p;
+    int T0ecart     = strat->T[0].ecart;
+
 
     d = h->GetpFDeg()+ h->ecart;
     reddeg = strat->LazyDegree+d;
     h->SetShortExpVector();
+    if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
+        docoeffred  = 1;
+    }
     loop
     {
         /* cut down the lead coefficients, only possible if the degree of
          * T[0] is 0 (constant). This is only efficient if T[0] is short, thus
          * we ask for the length of T[0] to be <= 2 */
-        if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
+        if (docoeffred) {
             j = kTestDivisibleByT0_Z(strat, h);
-            if (j == 0 && n_DivBy(pGetCoeff(h->p), pGetCoeff(strat->T[j].p), currRing->cf) == FALSE) {
-                if (strat->T[j].ecart <= h->ecart) {
-                    /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
-                     * => we try to cut down the lead coefficient at least */
-                    /* first copy T[j] in order to multiply it with a coefficient later on */
-                    number mult, rest;
-                    TObject tj  = strat->T[j];
-                    tj.Copy();
-                    /* compute division with remainder of lc(h) and lc(T[j]) */
-                    mult = n_QuotRem(pGetCoeff(h->p), pGetCoeff(strat->T[j].p),
-                            &rest, currRing->cf);
-                    /* set corresponding new lead coefficient already. we do not
-                     * remove the lead term in ksReducePolyLC, but only apply
-                     * a lead coefficient reduction */
-                    tj.Mult_nn(mult);
-                    ksReducePolyLC(h, &tj, NULL, &rest, strat);
-                    tj.Delete();
-                    tj.Clear();
-                }
+            if (j == 0 && n_DivBy(pGetCoeff(h->p), pGetCoeff(T0p), currRing->cf) == FALSE
+                    && T0ecart <= h->ecart) {
+                /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
+                 * => we try to cut down the lead coefficient at least */
+                /* first copy T[j] in order to multiply it with a coefficient later on */
+                number mult, rest;
+                TObject tj  = strat->T[0];
+                tj.Copy();
+                /* compute division with remainder of lc(h) and lc(T[j]) */
+                mult = n_QuotRem(pGetCoeff(h->p), pGetCoeff(T0p),
+                        &rest, currRing->cf);
+                /* set corresponding new lead coefficient already. we do not
+                 * remove the lead term in ksReducePolyLC, but only apply
+                 * a lead coefficient reduction */
+                tj.Mult_nn(mult);
+                ksReducePolyLC(h, &tj, NULL, &rest, strat);
+                tj.Delete();
+                tj.Clear();
             }
         }
         j = kFindDivisibleByInT(strat, h);
@@ -974,37 +980,42 @@ static poly redMoraNFRing (poly h,kStrategy strat, int flag)
     H.p = h;
     int j0, j = 0;
     int z = 10;
+    int docoeffred  = 0;
+    poly T0p    = strat->T[0].p;
+    int T0ecart = strat->T[0].ecart;
     int o = H.SetpFDeg();
     H.ecart = currRing->pLDeg(H.p,&H.length,currRing)-o;
     if ((flag & 2) == 0) cancelunit(&H,TRUE);
     H.sev = pGetShortExpVector(H.p);
     unsigned long not_sev = ~ H.sev;
+    if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
+        docoeffred  = 1;
+    }
     loop
     {
         /* cut down the lead coefficients, only possible if the degree of
          * T[0] is 0 (constant). This is only efficient if T[0] is short, thus
          * we ask for the length of T[0] to be <= 2 */
-        if (strat->T[0].GetpFDeg() == 0 && strat->T[0].length <= 2) {
+        if (docoeffred) {
             j0 = kTestDivisibleByT0_Z(strat, &H);
-            if (j0 == 0 && n_DivBy(pGetCoeff(H.p), pGetCoeff(strat->T[j0].p), currRing->cf) == FALSE) {
-                if (strat->T[j0].ecart <= H.ecart) {
-                    /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
-                     * => we try to cut down the lead coefficient at least */
-                    /* first copy T[j0] in order to multiply it with a coefficient later on */
-                    number mult, rest;
-                    TObject tj  = strat->T[j0];
-                    tj.Copy();
-                    /* compute division with remainder of lc(h) and lc(T[j]) */
-                    mult = n_QuotRem(pGetCoeff(H.p), pGetCoeff(strat->T[j0].p),
-                            &rest, currRing->cf);
-                    /* set corresponding new lead coefficient already. we do not
-                     * remove the lead term in ksReducePolyLC, but only apply
-                     * a lead coefficient reduction */
-                    tj.Mult_nn(mult);
-                    ksReducePolyLC(&H, &tj, NULL, &rest, strat);
-                    tj.Delete();
-                    tj.Clear();
-                }
+            if (j0 == 0 && n_DivBy(pGetCoeff(H.p), pGetCoeff(T0p), currRing->cf) == FALSE
+                    && T0ecart <= H.ecart) {
+                /* not(lc(reducer) | lc(poly)) && not(lc(poly) | lc(reducer))
+                 * => we try to cut down the lead coefficient at least */
+                /* first copy T[j0] in order to multiply it with a coefficient later on */
+                number mult, rest;
+                TObject tj  = strat->T[0];
+                tj.Copy();
+                /* compute division with remainder of lc(h) and lc(T[j]) */
+                mult = n_QuotRem(pGetCoeff(H.p), pGetCoeff(T0p),
+                        &rest, currRing->cf);
+                /* set corresponding new lead coefficient already. we do not
+                 * remove the lead term in ksReducePolyLC, but only apply
+                 * a lead coefficient reduction */
+                tj.Mult_nn(mult);
+                ksReducePolyLC(&H, &tj, NULL, &rest, strat);
+                tj.Delete();
+                tj.Clear();
             }
         }
         if (j > strat->tl)

--- a/kernel/GBEngine/kstd1.cc
+++ b/kernel/GBEngine/kstd1.cc
@@ -981,7 +981,6 @@ static poly redMoraNFRing (poly h,kStrategy strat, int flag)
     unsigned long not_sev = ~ H.sev;
     loop
     {
-#if 1
         /* cut down the lead coefficients, only possible if the degree of
          * T[0] is 0 (constant). This is only efficient if T[0] is short, thus
          * we ask for the length of T[0] to be <= 2 */
@@ -1008,7 +1007,6 @@ static poly redMoraNFRing (poly h,kStrategy strat, int flag)
                 }
             }
         }
-#endif
         if (j > strat->tl)
         {
             return H.p;

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -136,6 +136,72 @@ int kFindSameLMInT_Z(const kStrategy strat, const LObject* L, const int start)
 }
 // return -1 if no divisor is found
 //        number of first divisor, otherwise
+int kFindDivisibleByInT_Z_only_first(const kStrategy strat, const LObject* L, const int start)
+{
+    if (strat->tl < 1)
+        return -1;
+
+  unsigned long not_sev = ~L->sev;
+  int j = start;
+  int o = -1;
+
+  const TSet T=strat->T;
+  const unsigned long* sevT=strat->sevT;
+  number rest, orest, mult;
+  if (L->p!=NULL)
+  {
+    const ring r=currRing;
+    const poly p=L->p;
+    orest = pGetCoeff(p);
+
+    pAssume(~not_sev == p_GetShortExpVector(p, r));
+
+#if defined(PDEBUG) || defined(PDIV_DEBUG)
+      if (p_LmShortDivisibleBy(strat->T[0].p, strat->sevT[0],p, not_sev, r))
+      {
+        mult= n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
+        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+            return 0;
+        }
+      }
+#else
+      if (!(strat->sevT[0] & not_sev) && p_LmDivisibleBy(strat->T[0].p, p, r))
+      {
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
+        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+            return 0;
+        }
+      }
+#endif
+  }
+  else
+  {
+    const ring r=strat->tailRing;
+    const poly p=L->t_p;
+    orest = pGetCoeff(p);
+      if (j > strat->tl) return o;
+#if defined(PDEBUG) || defined(PDIV_DEBUG)
+      if (p_LmShortDivisibleBy(strat->T[0].t_p, sevT[j],
+            p, not_sev, r))
+      {
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
+        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+            return 0;
+        }
+      }
+#else
+      if (!(strat->sevT[0] & not_sev) && p_LmDivisibleBy(strat->T[0].t_p, p, r))
+      {
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
+        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+            return 0;
+        }
+      }
+#endif
+  }
+  return -1;
+}
+
 int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int start)
 {
   unsigned long not_sev = ~L->sev;

--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -134,72 +134,68 @@ int kFindSameLMInT_Z(const kStrategy strat, const LObject* L, const int start)
     }
   }
 }
-// return -1 if no divisor is found
-//        number of first divisor, otherwise
-int kFindDivisibleByInT_Z_only_first(const kStrategy strat, const LObject* L, const int start)
+// return -1 if T[0] does not divide the leading monomial
+int kTestDivisibleByT0_Z(const kStrategy strat, const LObject* L)
 {
     if (strat->tl < 1)
         return -1;
 
-  unsigned long not_sev = ~L->sev;
-  int j = start;
-  int o = -1;
+    unsigned long not_sev     = ~L->sev;
+    const unsigned long sevT0 = strat->sevT[0];
+    number rest, orest, mult;
+    if (L->p!=NULL)
+    {
+        const poly T0p  = strat->T[0].p;
+        const ring r    = currRing;
+        const poly p    = L->p;
+        orest           = pGetCoeff(p);
 
-  const TSet T=strat->T;
-  const unsigned long* sevT=strat->sevT;
-  number rest, orest, mult;
-  if (L->p!=NULL)
-  {
-    const ring r=currRing;
-    const poly p=L->p;
-    orest = pGetCoeff(p);
-
-    pAssume(~not_sev == p_GetShortExpVector(p, r));
+        pAssume(~not_sev == p_GetShortExpVector(p, r));
 
 #if defined(PDEBUG) || defined(PDIV_DEBUG)
-      if (p_LmShortDivisibleBy(strat->T[0].p, strat->sevT[0],p, not_sev, r))
-      {
-        mult= n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
-        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
-            return 0;
+        if (p_LmShortDivisibleBy(T0p, sevT0, not_sev, r))
+        {
+            mult= n_QuotRem(pGetCoeff(p), pGetCoeff(T0p), &rest, r->cf);
+            if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+                return 0;
+            }
         }
-      }
 #else
-      if (!(strat->sevT[0] & not_sev) && p_LmDivisibleBy(strat->T[0].p, p, r))
-      {
-        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
-        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
-            return 0;
+        if (!(sevT0 & not_sev) && p_LmDivisibleBy(T0p, p, r))
+        {
+            mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T0p), &rest, r->cf);
+            if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+                return 0;
+            }
         }
-      }
 #endif
-  }
-  else
-  {
-    const ring r=strat->tailRing;
-    const poly p=L->t_p;
-    orest = pGetCoeff(p);
-      if (j > strat->tl) return o;
+    }
+    else
+    {
+        const poly T0p  = strat->T[0].t_p;
+        const ring r    = strat->tailRing;
+        const poly p    = L->t_p;
+        orest           = pGetCoeff(p);
 #if defined(PDEBUG) || defined(PDIV_DEBUG)
-      if (p_LmShortDivisibleBy(strat->T[0].t_p, sevT[j],
-            p, not_sev, r))
-      {
-        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
-        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
-            return 0;
+        if (p_LmShortDivisibleBy(strat->T[0].t_p, sevT[j],
+                    p, not_sev, r))
+        {
+            mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T0p), &rest, r->cf);
+            if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+                return 0;
+            }
         }
-      }
 #else
-      if (!(strat->sevT[0] & not_sev) && p_LmDivisibleBy(strat->T[0].t_p, p, r))
-      {
-        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(strat->T[0].p), &rest, r->cf);
-        if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
-            return 0;
+        if (!(sevT0 & not_sev) && p_LmDivisibleBy(T0p, p, r))
+        {
+            mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T0p), &rest, r->cf);
+            if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
+                return 0;
+            }
         }
-      }
 #endif
-  }
-  return -1;
+    }
+    return -1;
 }
 
 int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int start)
@@ -256,7 +252,7 @@ int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int sta
       if (p_LmShortDivisibleBy(T[j].t_p, sevT[j],
             p, not_sev, r))
       {
-        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].p), &rest, r->cf);
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].t_p), &rest, r->cf);
         if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
           o = j;
           orest = rest;
@@ -265,7 +261,7 @@ int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int sta
 #else
       if (!(sevT[j] & not_sev) && p_LmDivisibleBy(T[j].t_p, p, r))
       {
-        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].p), &rest, r->cf);
+        mult = n_QuotRem(pGetCoeff(p), pGetCoeff(T[j].t_p), &rest, r->cf);
         if (!n_IsZero(mult, r) && n_Greater(n_EucNorm(orest, r->cf), n_EucNorm(rest, r->cf), r->cf) == TRUE) {
           o = j;
           orest = rest;

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -599,9 +599,10 @@ int kFindInT(poly p, TSet T, int tlength);
 ///        number of first divisor in T, otherwise
 int kFindDivisibleByInT(const kStrategy strat, const LObject* L, const int start=0);
 int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int start=0);
-int kFindDivisibleByInT_Z_only_first(const kStrategy strat, const LObject* L, const int start=0);
 int kFindSameLMInT_Z(const kStrategy strat, const LObject* L, const int start=0);
 
+/// tests if T[0] divides the leading monomial of L, returns -1 if not
+int kTestDivisibleByT0_Z(const kStrategy strat, const LObject* L);
 /// return -1 if no divisor is found
 ///        number of first divisor in S, otherwise
 int kFindDivisibleByInS(const kStrategy strat, int *max_ind, LObject* L);

--- a/kernel/GBEngine/kutil.h
+++ b/kernel/GBEngine/kutil.h
@@ -599,6 +599,7 @@ int kFindInT(poly p, TSet T, int tlength);
 ///        number of first divisor in T, otherwise
 int kFindDivisibleByInT(const kStrategy strat, const LObject* L, const int start=0);
 int kFindDivisibleByInT_Z(const kStrategy strat, const LObject* L, const int start=0);
+int kFindDivisibleByInT_Z_only_first(const kStrategy strat, const LObject* L, const int start=0);
 int kFindSameLMInT_Z(const kStrategy strat, const LObject* L, const int start=0);
 
 /// return -1 if no divisor is found


### PR DESCRIPTION
Adds redRiLoc_Z and updates redMoraNFRing: Tries to cut down leading coefficients as much as possible if lead term reductions are not possible for local std computations over the integers.