### PR TITLE
Fix compiler warning by removing use of `register`

### DIFF
--- a/factory/ffops.h
+++ b/factory/ffops.h
@@ -151,7 +151,7 @@ inline int ff_inv ( const int a )
     if ( ff_big )
         return ff_biginv( a );
     else {
-        register int b;
+        int b;
         if ( (b = (int)(ff_invtab[a])) )
             return b;
         else


### PR DESCRIPTION
For modern C compilers, this keyword has no effect at all (for GCC
at least since GCC 3, released almost two decades ago).