### PR TITLE
Improve performance of liftstd

### DIFF
--- a/kernel/GBEngine/kstd2.cc
+++ b/kernel/GBEngine/kstd2.cc
@@ -1798,6 +1798,23 @@ int redHoney (LObject* h, kStrategy strat)
         }
       }
     }
+    if (strat->syzComp > 0)
+    {
+      if (h->p!=NULL)
+      {
+        if(p_GetComp(h->p,currRing)>strat->syzComp)
+        {
+          return 1;
+        }
+      }
+      else if (h->t_p!=NULL)
+      {
+        if(p_GetComp(h->t_p,strat->tailRing)>strat->syzComp)
+        {
+          return 1;
+        }
+      }
+    }
     h->SetShortExpVector();
     not_sev = ~ h->sev;
     h_d = h->SetpFDeg();


### PR DESCRIPTION
I'm investigating the performance of `liftstd` (see #925) and think there is a large potential for optimizations. This commit stops the reduction in `redHoney` once the entries of the actual Gröbner basis are zero (instead of continuing the reduction with the entries of the transformation matrix). This is analogous to https://github.com/zickgraf/Singular/blob/0bb946880d425f56c1db84b42ea61b5ece5de8e9/kernel/GBEngine/kstd2.cc#L1782 but I do not delete `h` and return 1 instead of 0 since the nonzero part of `h` is needed for the syzygies. This improves the runtime of `liftstd` in the following example from 6900ms to 1700ms on my computer (for larger examples the difference is even greater):

```
LIB "random.lib";
// make random reproducible
system("random", 1);
system("--ticks-per-sec",1000);

int t;

ring R = 0,(x,y,z),(c,dp);
matrix A = randommat(20, 700, maxideal(1), 10);
// we want to test redHoney, so A should not be homogeneous since in this case redHomog would be used
A[1,1] = x^2;

t = timer;
matrix G1 = std(A);
print("computed std in " + string(timer - t) + " ms");

matrix T;
module S;
t = timer;
matrix G2 = liftstd(A, T, S);
print("computed liftstd in " + string(timer - t) + " ms");
```

If this PR gets merged I will provide PRs for the other `red...` functions.

Edit: Of course this changes the result of syzygy computations so some tests are failing. If we are sure that this change is mathematically correct, I will update the tests.