### PR TITLE
sane detection for standard paths installation of flint

### DIFF
--- a/m4/flint-check.m4
+++ b/m4/flint-check.m4
@@ -13,7 +13,7 @@ dnl FLINT_CFLAGS and FLINT_LIBS
 
 AC_DEFUN([LB_CHECK_FLINT],
 [
-DEFAULT_CHECKING_PATH="/usr /usr/local /sw /opt/local"
+DEFAULT_CHECKING_PATH="/sw /opt/local"
 
 AC_ARG_WITH(flint,
 [  --with-flint=<path>|yes|no  Use FLINT library. If argument is no, you do not have
@@ -40,26 +40,47 @@ fi
 
 AC_LANG_PUSH([C])
 
-for FLINT_HOME in ${FLINT_HOME_PATH}
- do
- if test -r "$FLINT_HOME/include/flint/fmpz.h"; then
-
-	FLINT_CFLAGS="-I${FLINT_HOME}/include/"
-	FLINT_LIBS="-L${FLINT_HOME}/lib -lflint -lmpfr"
+flint_found="no"
+dnl check for system installed libraries if FLINT_HOME_PATH is the default
+if test "$FLINT_HOME_PATH" = "$DEFAULT_CHECKING_PATH" ; then
+	FLINT_CFLAGS=""
+	FLINT_LIBS="-lflint -lmpfr"
 
 	# we suppose that mpfr and mpir to be in the same place or available by default
-	CFLAGS="${BACKUP_CFLAGS} ${FLINT_CFLAGS} ${GMP_CPPFLAGS}"
+	CFLAGS="${BACKUP_CFLAGS} ${GMP_CPPFLAGS}"
 	LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUPLIBS}"
 
-	AC_CHECK_LIB(flint,fmpz_init,
-	[flint_found="yes"],
-	[flint_found="mo"],
-	[]
-	)
-else
-	flint_found="no"
+	AC_CHECK_HEADER([flint/fmpz.h],
+		[AC_CHECK_LIB(flint,fmpz_init,
+			[flint_found="yes"],
+			[],
+			[])],
+		[],
+		[])
 fi
-done
+
+dnl if flint was not previously found, search FLINT_HOME_PATH
+if test "x$flint_found" = "xno" ; then
+	for FLINT_HOME in ${FLINT_HOME_PATH}
+	do
+		if test -r "$FLINT_HOME/include/flint/fmpz.h"; then
+
+		FLINT_CFLAGS="-I${FLINT_HOME}/include/"
+		FLINT_LIBS="-L${FLINT_HOME}/lib -lflint -lmpfr"
+
+	# we suppose that mpfr and mpir to be in the same place or available by default
+		CFLAGS="${BACKUP_CFLAGS} ${FLINT_CFLAGS} ${GMP_CPPFLAGS}"
+		LIBS="${FLINT_LIBS} ${GMP_LIBS} ${BACKUPLIBS}"
+
+		AC_CHECK_LIB(flint,fmpz_init,
+		[flint_found="yes"],
+		[],
+		[]
+		)
+		fi
+	done
+fi
+
 AC_LANG_POP([C])
 
 CFLAGS=${BACKUP_CFLAGS}


### PR DESCRIPTION
It all started because I had enough of that kind of garbage during linking in my logs
```
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible /usr/lib/libpthread.so when searching for -lpthread
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible /usr/lib/libpthread.a when searching for -lpthread
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible /usr/lib/libm.so when searching for -lm
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible /usr/lib/libm.a when searching for -lm
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible /usr/lib/libc.so when searching for -lc
/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: skipping incompatible /usr/lib/libc.a when searching for -lc
```
because the current flint detection includes the line `FLINT_LIBS="-L${FLINT_HOME}/lib -lflint -lmpfr"` which is of course wrong on my system since libflint.so lives in `/usr/lib64`. I could have a 32bits version in `/usr/lib` but that doesn't help for my default install.

The current code uses a blanket detection by location code which is inherently overkill and wrong when flint is installed in standard location like `/usr` or `/usr/local`. Moreover it forces you to pass `--with-flint=$somepath` even if you have properly set up your system with `CPATH` and `LIBRARY_PATH` so that your compiler can find `flint` without any additional flags.

This pulls request separates the testing of standard (and enhanced) location. If a `FLINT_HOME_PATH` is not given, it checks if the compiler can find the headers and libraries without any `-I` or `-L` flags. It then proceeds to check `/sw` and `/opt/local` as before if flint is not reachable by the compiler by default. If `FLINT_HOME_PATH` is given, the old code is used to check the installation.

I tried for minimal invasion of the old code so it was still easy to understand.

I also eliminated the funny typo `flint_found="mo"`.