### PR TITLE
More cross compiling

### DIFF
--- a/libpolys/configure.ac
+++ b/libpolys/configure.ac
@@ -14,7 +14,7 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 dnl Check if build env is sane
 AM_SANITY_CHECK
 
-AX_PROG_CC_FOR_BUILD
+AX_PROG_CXX_FOR_BUILD
 
 # Add pre'prefixed config
 AX_PREFIX_CONFIG_H([libpolysconfig.h],[],[_config.h])

--- a/libpolys/polys/Makefile.am
+++ b/libpolys/polys/Makefile.am
@@ -111,9 +111,8 @@ p_Procs_Generate_CPPFLAGS = ${AM_CPPFLAGS} ${USE_P_PROCS_STATIC}
 BUILT_SOURCES = prCopy.inc gftables MOD templates/p_Procs.inc
 
 templates/p_Procs.inc: p_Procs_Generate.cc
-	$(MAKE) $(AM_MAKEFLAGS) CC="$(CC_FOR_BUILD)" LD="$CC_FOR_BUILDHOSTLD)" \
-	p_Procs_Generate
-	./p_Procs_Generate$(EXEEXT) > ./templates/p_Procs.inc
+	$(MAKE) $(AM_MAKEFLAGS) CXX="$(CXX_FOR_BUILD)" p_Procs_Generate
+	./p_Procs_Generate$(BUILD_EXEEXT) > ./templates/p_Procs.inc
 
 prCopy.inc: prCopy.pl
 	perl ${srcdir}/prCopy.pl >  prCopy.inc

--- a/m4/ax_prog_cxx_for_build.m4
+++ b/m4/ax_prog_cxx_for_build.m4
@@ -1,0 +1,110 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_prog_cxx_for_build.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_CXX_FOR_BUILD
+#
+# DESCRIPTION
+#
+#   This macro searches for a C++ compiler that generates native
+#   executables, that is a C++ compiler that surely is not a cross-compiler.
+#   This can be useful if you have to generate source code at compile-time
+#   like for example GCC does.
+#
+#   The macro sets the CXX_FOR_BUILD and CXXCPP_FOR_BUILD macros to anything
+#   needed to compile or link (CXX_FOR_BUILD) and preprocess
+#   (CXXCPP_FOR_BUILD). The value of these variables can be overridden by
+#   the user by specifying a compiler with an environment variable (like you
+#   do for standard CXX).
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Paolo Bonzini <bonzini@gnu.org>
+#   Copyright (c) 2012 Avionic Design GmbH
+#
+#   Based on the AX_PROG_CC_FOR_BUILD macro by Paolo Bonzini.
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 3
+
+AU_ALIAS([AC_PROG_CXX_FOR_BUILD], [AX_PROG_CXX_FOR_BUILD])
+AC_DEFUN([AX_PROG_CXX_FOR_BUILD], [dnl
+AC_REQUIRE([AX_PROG_CC_FOR_BUILD])dnl
+AC_REQUIRE([AC_PROG_CXX])dnl
+AC_REQUIRE([AC_PROG_CXXCPP])dnl
+AC_REQUIRE([AC_CANONICAL_HOST])dnl
+
+dnl Use the standard macros, but make them use other variable names
+dnl
+pushdef([ac_cv_prog_CXXCPP], ac_cv_build_prog_CXXCPP)dnl
+pushdef([ac_cv_prog_gxx], ac_cv_build_prog_gxx)dnl
+pushdef([ac_cv_prog_cxx_works], ac_cv_build_prog_cxx_works)dnl
+pushdef([ac_cv_prog_cxx_cross], ac_cv_build_prog_cxx_cross)dnl
+pushdef([ac_cv_prog_cxx_g], ac_cv_build_prog_cxx_g)dnl
+pushdef([CXX], CXX_FOR_BUILD)dnl
+pushdef([CXXCPP], CXXCPP_FOR_BUILD)dnl
+pushdef([CXXFLAGS], CXXFLAGS_FOR_BUILD)dnl
+pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
+pushdef([CXXCPPFLAGS], CXXCPPFLAGS_FOR_BUILD)dnl
+pushdef([host], build)dnl
+pushdef([host_alias], build_alias)dnl
+pushdef([host_cpu], build_cpu)dnl
+pushdef([host_vendor], build_vendor)dnl
+pushdef([host_os], build_os)dnl
+pushdef([ac_cv_host], ac_cv_build)dnl
+pushdef([ac_cv_host_alias], ac_cv_build_alias)dnl
+pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
+pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
+pushdef([ac_cv_host_os], ac_cv_build_os)dnl
+pushdef([ac_cxxcpp], ac_build_cxxcpp)dnl
+pushdef([ac_compile], ac_build_compile)dnl
+pushdef([ac_link], ac_build_link)dnl
+
+save_cross_compiling=$cross_compiling
+save_ac_tool_prefix=$ac_tool_prefix
+cross_compiling=no
+ac_tool_prefix=
+
+AC_PROG_CXX
+AC_PROG_CXXCPP
+
+ac_tool_prefix=$save_ac_tool_prefix
+cross_compiling=$save_cross_compiling
+
+dnl Restore the old definitions
+dnl
+popdef([ac_link])dnl
+popdef([ac_compile])dnl
+popdef([ac_cxxcpp])dnl
+popdef([ac_cv_host_os])dnl
+popdef([ac_cv_host_vendor])dnl
+popdef([ac_cv_host_cpu])dnl
+popdef([ac_cv_host_alias])dnl
+popdef([ac_cv_host])dnl
+popdef([host_os])dnl
+popdef([host_vendor])dnl
+popdef([host_cpu])dnl
+popdef([host_alias])dnl
+popdef([host])dnl
+popdef([CXXCPPFLAGS])dnl
+popdef([CPPFLAGS])dnl
+popdef([CXXFLAGS])dnl
+popdef([CXXCPP])dnl
+popdef([CXX])dnl
+popdef([ac_cv_prog_cxx_g])dnl
+popdef([ac_cv_prog_cxx_cross])dnl
+popdef([ac_cv_prog_cxx_works])dnl
+popdef([ac_cv_prog_gxx])dnl
+popdef([ac_cv_prog_CXXCPP])dnl
+
+dnl Finally, set Makefile variables
+dnl
+AC_SUBST([CXXFLAGS_FOR_BUILD])dnl
+AC_SUBST([CXXCPPFLAGS_FOR_BUILD])dnl
+])

--- a/omalloc/Makefile.am
+++ b/omalloc/Makefile.am
@@ -40,12 +40,12 @@ libomalloc_la_CPPFLAGS  = ${AM_CPPFLAGS} -DOM_ALLOC_INTERNAL
 BUILT_SOURCES = omTables.inc omTables.h
 
 omTables.inc:
-	$(MAKE) $(AM_MAKEFLAGS) CC="${CC_FOR_BUILD}" LD="${CC_FOR_BUILD}" omTables
-	./omTables$(EXEEXT) > omTables.xx && mv omTables.xx  omTables.inc
+	$(MAKE) $(AM_MAKEFLAGS) CC="${CC_FOR_BUILD}" omTables
+	./omTables$(BUILD_EXEEXT) > omTables.xx && mv omTables.xx  omTables.inc
 
 omTables.h:
-	$(MAKE) $(AM_MAKEFLAGS) CC="${CC_FOR_BUILD}" LD="${CC_FOR_BUILD}" omTables1
-	./omTables1$(EXEEXT) >omTables.yy && mv omTables.yy omTables.h
+	$(MAKE) $(AM_MAKEFLAGS) CC="${CC_FOR_BUILD}" omTables1
+	./omTables1$(BUILD_EXEEXT) >omTables.yy && mv omTables.yy omTables.h
 
 noinst_PROGRAMS = omTables omTables1
 omTables_SOURCES = omAllocPrivate.h omTables.c


### PR DESCRIPTION
- use CXX_FOR_BUILD for C++ sources
- use BUILD_EXEEXT instead of EXEEXT
- don't bother settings the unused LD variables (in one case it was set to a bogus value anyway)

Together with 26b42ddcca6857a388490aa8398e5ed81434ab0e this hopefully resolves #1001