### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ _config.h.in
 /libpolys/libpolysconfig.h
 /libpolys/libpolysconfig.h.in
 /libpolys/polys/m4/
-/libpolys/polys/templates/p_Procs_Generate
+/libpolys/polys/p_Procs_Generate
 /libpolys/polys/templates/p_Procs.inc
 /libpolys/tests/gftables
 /libpolys/tests/p_Procs_*.so
@@ -62,6 +62,7 @@ _config.h.in
 /omalloc/omConfig.h.in
 /omalloc/omExternalConfig.h
 /omalloc/omTables
+/omalloc/omTables1
 /omalloc/omTables.dSYM/*
 /omalloc/omTables.h
 /omalloc/omTables.inc


### PR DESCRIPTION
By the way: I noticed that there are plenty of additional `.gitignore` files, e.g. `omalloc/.gitignore`. But confusingly, also the main `.gitignore` file lists file in `omalloc`. Is there a patter to this? I think it would be better to have all ignore rules for each directory in a single `.gitignore` file (i.e. either merge `omalloc/.gitignore` into the main `.gitignore`; or move all `omalloc` related rules from the main `.gitignore` to `omalloc/.gitignore`. @hannes14 thoughts?