### PR TITLE
Unify access to sigcontext on Linux + x86

### DIFF
--- a/Singular/cntrlc.cc
+++ b/Singular/cntrlc.cc
@@ -4,6 +4,11 @@
 /*
 * ABSTRACT - interupt handling
 */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include "kernel/mod2.h"
 
 #include "reporter/si_signals.h"
@@ -154,47 +159,7 @@ si_hdl_typ si_set_signal ( int sig, si_hdl_typ signal_handler)
 
 
 /*---------------------------------------------------------------------*/
-#if defined(__linux__) && defined(__i386)
-  #if !defined(HAVE_SIGCONTEXT) && !defined(HAVE_ASM_SIGCONTEXT_H)
-// we need the following structure sigcontext_struct.
-// if configure finds asm/singcontext.h we assume
-// that this file contains the structure and is included
-// via signal.h
-struct sigcontext_struct {
-        unsigned short gs, __gsh;
-        unsigned short fs, __fsh;
-        unsigned short es, __esh;
-        unsigned short ds, __dsh;
-        unsigned long edi;
-        unsigned long esi;
-        unsigned long ebp;
-        unsigned long esp;
-        unsigned long ebx;
-        unsigned long edx;
-        unsigned long ecx;
-        unsigned long eax;
-        unsigned long trapno;
-        unsigned long err;
-        unsigned long eip;
-        unsigned short cs, __csh;
-        unsigned long eflags;
-        unsigned long esp_at_signal;
-        unsigned short ss, __ssh;
-        unsigned long i387;
-        unsigned long oldmask;
-        unsigned long cr2;
-};
-#endif
-#define HAVE_SIGSTRUCT
-typedef struct sigcontext_struct sigcontext;
-#endif
-
-#if defined(__linux__) && defined(__amd64)
-#define HAVE_SIGSTRUCT
-#endif
-
-
-#if defined(HAVE_SIGSTRUCT)
+#if defined(__linux__) && (defined(__i386) || defined(__amd64))
 /*2---------------------------------------------------------------------*/
 /**
  * @brief signal handler for run time errors, linux/i386, x86_64 version


### PR DESCRIPTION
This fixes compatibility on 32 bit systems with the muslc C library